### PR TITLE
BG-3 - Improved move previews

### DIFF
--- a/bishopsGambit/src/core/Game.java
+++ b/bishopsGambit/src/core/Game.java
@@ -17,7 +17,7 @@ import players.Player.Colour;
 
 public class Game {
 
-	private final List<Board> boards = new ArrayList<Board>();
+	private final List<Board> boards = new ArrayList<>();
 
 	private final Player white = new Player(Colour.WHITE);
 	private final Player black = new Player(Colour.BLACK);
@@ -77,7 +77,7 @@ public class Game {
 		return n % 2 == 0 ? getWhite() : getBlack();
 	}
 
-	public Board move(Square from, Square to, Typ prom) {
+	public void move(Square from, Square to, Typ prom) {
 		if (!from.isOccupied())
 			throw new UnoccupiedSquareException(from);
 
@@ -144,8 +144,6 @@ public class Game {
 		}
 
 		addBoard(newBoard);
-
-		return newBoard;
 	}
 
 }

--- a/bishopsGambit/src/gui/SButton.java
+++ b/bishopsGambit/src/gui/SButton.java
@@ -1,10 +1,15 @@
 package gui;
 
 import java.awt.Color;
+import java.awt.Image;
 
 import javax.swing.BorderFactory;
+import javax.swing.Icon;
+import javax.swing.ImageIcon;
 import javax.swing.JButton;
 
+import board.Board;
+import board.Square;
 import utils.ColorUtils;
 import utils.ComponentUtils;
 
@@ -15,16 +20,22 @@ public class SButton extends JButton {
 	private static final Color HIGHLIGHT = ColorUtils.blend(Color.yellow, Color.white);
 	private static final Color BLACK_SEMI_TRANSPARENT = ColorUtils.changeAlpha(Color.black, 85);
 
-	private final Color defaultBg;
+	private final char file;
+	private final int rank;
 
-	private Color getDefaultBg() {
-		return this.defaultBg;
+	public char getFile() {
+		return this.file;
+	}
+
+	public int getRank() {
+		return this.rank;
 	}
 
 	public SButton(char file, int rank) {
-		this.defaultBg = (file + rank) % 2 == 0 ? DARK : LIGHT;
+		this.file = file;
+		this.rank = rank;
 
-		resetBorder();
+		clearBorder();
 		resetBackground();
 
 		setForeground(BLACK_SEMI_TRANSPARENT);
@@ -32,7 +43,11 @@ public class SButton extends JButton {
 		setOpaque(true);
 	}
 
-	public void resetBorder() {
+	private Color getDefaultBg() {
+		return (getFile() + getRank()) % 2 == 0 ? DARK : LIGHT;
+	}
+
+	public void clearBorder() {
 		setBorder(BorderFactory.createEmptyBorder());
 	}
 
@@ -72,6 +87,27 @@ public class SButton extends JButton {
 	public void setScale(int scale) {
 		setSize(scale, scale);
 		ComponentUtils.resizeFont(this, scale);
+	}
+
+	/**
+	 * Sets this button's icon to an image of the piece occupying its corresponding
+	 * square. The corresponding square is the square on the given <b>board</b> that
+	 * has the same file and rank as this button. If the square is not occupied by
+	 * any piece, an empty icon is set.
+	 * 
+	 * @param board the board
+	 */
+	public void paintIcon(Board board) {
+		Icon icon = null;
+
+		Square square = board.getSquare(getFile(), getRank());
+		if (square.isOccupied()) {
+			Image imageFull = square.getPiece().getImage();
+			Image imageScaled = imageFull.getScaledInstance(getWidth(), getHeight(), Image.SCALE_SMOOTH);
+			icon = new ImageIcon(imageScaled);
+		}
+
+		setIcon(icon);
 	}
 
 }

--- a/bishopsGambit/src/pieces/Bishop.java
+++ b/bishopsGambit/src/pieces/Bishop.java
@@ -29,7 +29,7 @@ public class Bishop extends Piece {
 	}
 
 	public static List<Square> getTargets(Board board, Piece piece) {
-		List<Square> targets = new ArrayList<Square>();
+		List<Square> targets = new ArrayList<>();
 
 		Square square = piece.getSquare(board);
 		char file = square.getFile();

--- a/bishopsGambit/src/pieces/King.java
+++ b/bishopsGambit/src/pieces/King.java
@@ -25,7 +25,7 @@ public class King extends Piece {
 
 	@Override
 	public List<Square> getTargets(Board board) {
-		List<Square> targets = new ArrayList<Square>();
+		List<Square> targets = new ArrayList<>();
 
 		Square square = getSquare(board);
 		char file = square.getFile();
@@ -45,7 +45,7 @@ public class King extends Piece {
 
 	@Override
 	public List<Square> getMoves(Board board) {
-		List<Square> moves = new ArrayList<Square>(super.getMoves(board));
+		List<Square> moves = new ArrayList<>(super.getMoves(board));
 
 		for (int x : new int[] { -1, 1 }) {
 			if (!hasMoved() && !isTargeted(board)) {

--- a/bishopsGambit/src/pieces/Knight.java
+++ b/bishopsGambit/src/pieces/Knight.java
@@ -25,7 +25,7 @@ public class Knight extends Piece {
 
 	@Override
 	public List<Square> getTargets(Board board) {
-		List<Square> targets = new ArrayList<Square>();
+		List<Square> targets = new ArrayList<>();
 
 		Square square = getSquare(board);
 		char file = square.getFile();

--- a/bishopsGambit/src/pieces/Pawn.java
+++ b/bishopsGambit/src/pieces/Pawn.java
@@ -35,7 +35,7 @@ public class Pawn extends Piece {
 
 	@Override
 	public List<Square> getTargets(Board board) {
-		List<Square> targets = new ArrayList<Square>();
+		List<Square> targets = new ArrayList<>();
 
 		Square square = getSquare(board);
 		char file = square.getFile();

--- a/bishopsGambit/src/pieces/Queen.java
+++ b/bishopsGambit/src/pieces/Queen.java
@@ -25,7 +25,7 @@ public class Queen extends Piece {
 
 	@Override
 	public List<Square> getTargets(Board board) {
-		List<Square> targets = new ArrayList<Square>();
+		List<Square> targets = new ArrayList<>();
 		targets.addAll(Bishop.getTargets(board, this));
 		targets.addAll(Rook.getTargets(board, this));
 		return targets;

--- a/bishopsGambit/src/pieces/Rook.java
+++ b/bishopsGambit/src/pieces/Rook.java
@@ -29,7 +29,7 @@ public class Rook extends Piece {
 	}
 
 	public static List<Square> getTargets(Board board, Piece piece) {
-		List<Square> targets = new ArrayList<Square>();
+		List<Square> targets = new ArrayList<>();
 
 		Square square = piece.getSquare(board);
 		char file = square.getFile();

--- a/bishopsGambit/src/players/Player.java
+++ b/bishopsGambit/src/players/Player.java
@@ -27,7 +27,7 @@ public class Player {
 	private final Colour colour;
 	private final int direction;
 
-	private final List<Piece> pieces = new ArrayList<Piece>();
+	private final List<Piece> pieces = new ArrayList<>();
 	private final Rook queensideRook;
 	private final Rook kingsideRook;
 	private final King king;

--- a/bishopsGambit/src/test/ChessTest.java
+++ b/bishopsGambit/src/test/ChessTest.java
@@ -81,15 +81,15 @@ class ChessTest {
 //	private static final String H7 = "h7";
 //	private static final String H8 = "h8";
 
-	public static Board move(Game game, String fromStr, String toStr) {
-		return move(game, fromStr, toStr, null);
+	public static void move(Game game, String fromStr, String toStr) {
+		move(game, fromStr, toStr, null);
 	}
 
-	public static Board move(Game game, String fromStr, String toStr, Typ prom) {
+	public static void move(Game game, String fromStr, String toStr, Typ prom) {
 		Board board = game.getBoard();
 		Square from = board.getSquare(fromStr);
 		Square to = board.getSquare(toStr);
-		return game.move(from, to, prom);
+		game.move(from, to, prom);
 	}
 
 	public static Piece getPiece(Board board, String squareStr) {

--- a/bishopsGambit/src/utils/ListUtils.java
+++ b/bishopsGambit/src/utils/ListUtils.java
@@ -1,0 +1,31 @@
+package utils;
+
+import java.util.List;
+
+public class ListUtils {
+
+	public static boolean hasIndex(List<?> list, int index) {
+		return 0 <= index && index < list.size();
+	}
+
+	/**
+	 * Finds the element in <b>list1</b> that has the same index as the given
+	 * <b>object</b> in <b>list2</b>.
+	 * 
+	 * @param <T>    the type of the element to be found
+	 * @param <U>    the type of the given <b>object</b>
+	 * @param list1  the list containing the element to be found
+	 * @param list2  the list containing the given <b>object</b>
+	 * @param object the object whose index we are interested in
+	 * @return the element in <b>list1</b> that has the same index as the given
+	 *         <b>object</b> in <b>list2</b>
+	 */
+	public static <T, U> T get(List<T> list1, List<U> list2, U object) {
+		T element = null;
+		int index;
+		if (object != null && hasIndex(list1, index = list2.indexOf(object)))
+			element = list1.get(index);
+		return element;
+	}
+
+}


### PR DESCRIPTION
Move previews now repaint every piece on the board. This ensures that for special moves such as castling and en passant, both components of the move (king and rook move for castling, pawn move and offending pawn capture for en passant) are now shown.

Castling before and after:

<img width=49% alt="Castling preview does not show the rook's destination square" src="https://github.com/OllyBishop/bishopsGambit/assets/21021117/6ae39bc6-fd38-48f9-8fbd-892e45c5d134">

<img width=49% alt="Castling preview" src="https://github.com/OllyBishop/bishopsGambit/assets/21021117/0002338e-2b4e-4c23-8179-f503d7dc49a9">

En passant before and after:

<img width=49% alt="En passant preview does not show the offending pawn being captured" src="https://github.com/OllyBishop/bishopsGambit/assets/21021117/5c49923d-54c4-4c7e-9fa4-13b3ce2e4e4c">

<img width=49% alt="En passant preview" src="https://github.com/OllyBishop/bishopsGambit/assets/21021117/fb5938c5-5e28-49aa-b096-c32b48d80a17">