### PR TITLE
BG-8 - Fixed bug where a player could castle through an enemy piece

### DIFF
--- a/bishopsGambit/src/board/Board.java
+++ b/bishopsGambit/src/board/Board.java
@@ -66,7 +66,7 @@ public class Board extends ArrayList<Square> {
 	 * 
 	 * @param file the file of the square to be found
 	 * @param rank the rank of the square to be found
-	 * @return the square with the given file and rank (if it exists), {@code null}
+	 * @return the square with the given file and rank (if it exists); {@code null}
 	 *         otherwise
 	 */
 	public Square getSquare(char file, int rank) {

--- a/bishopsGambit/src/board/Square.java
+++ b/bishopsGambit/src/board/Square.java
@@ -79,7 +79,7 @@ public class Square {
 	/**
 	 * Returns a boolean indicating whether or not this square is occupied.
 	 * 
-	 * @return {@code true} if this square contains a piece, {@code false} otherwise
+	 * @return {@code true} if this square contains a piece; {@code false} otherwise
 	 */
 	public boolean isOccupied() {
 		return getPiece() != null;
@@ -91,7 +91,7 @@ public class Square {
 	 * 
 	 * @param player the player
 	 * @return {@code true} if this square contains a piece belonging to the given
-	 *         player, {@code false} otherwise
+	 *         player; {@code false} otherwise
 	 */
 	public boolean isOccupiedBy(Player player) {
 		return player.getPieces().contains(getPiece());
@@ -103,7 +103,7 @@ public class Square {
 	 * 
 	 * @param player the player
 	 * @return {@code true} if this square contains a piece <i>not</i> belonging to
-	 *         the given player, {@code false} otherwise
+	 *         the given player; {@code false} otherwise
 	 */
 	public boolean isOccupiedByOpponent(Player player) {
 		return isOccupied() && !isOccupiedBy(player);
@@ -111,14 +111,16 @@ public class Square {
 
 	/**
 	 * Returns a boolean indicating whether or not this square is being targeted by
-	 * an enemy piece.
+	 * a piece <i>not</i> belonging to the given player.
 	 * 
-	 * @param board the chess board
-	 * @return {@code true} if this square is being targeted, {@code false}
-	 *         otherwise
+	 * @param board  the chess board
+	 * @param player the player
+	 * @return {@code true} if this square is being targeted by a piece <i>not</i>
+	 *         belonging to the given player; {@code false} otherwise
 	 */
-	public boolean isTargeted(Board board) {
-		return board.getPieces().stream().anyMatch(pc -> pc.isTargeting(board, this));
+	public boolean isTargeted(Board board, Player player) {
+		return board.getPieces().stream().filter(pc -> pc.getPlayer() != player)
+				.anyMatch(pc -> pc.isTargeting(board, this));
 	}
 
 	public Square travel(Board board, int x, int y) {

--- a/bishopsGambit/src/core/Game.java
+++ b/bishopsGambit/src/core/Game.java
@@ -73,7 +73,7 @@ public class Game {
 	 * Returns the player whose turn it currently is, based on the number of turns
 	 * taken.
 	 * 
-	 * @return White if the number of turns taken is even, Black if it is odd
+	 * @return White if the number of turns taken is even; Black if it is odd
 	 */
 	public Player getCurrentPlayer() {
 		return numberOfTurnsTaken() % 2 == 0 ? getWhite() : getBlack();
@@ -83,7 +83,7 @@ public class Game {
 	 * Returns the opponent of the player whose turn it currently is, based on the
 	 * number of turns taken.
 	 * 
-	 * @return Black if the number of turns taken is even, White if it is odd
+	 * @return Black if the number of turns taken is even; White if it is odd
 	 */
 	public Player getCurrentOpponent() {
 		return numberOfTurnsTaken() % 2 == 0 ? getBlack() : getWhite();
@@ -93,16 +93,14 @@ public class Game {
 		return move(fromStr, toStr, null);
 	}
 
-	public Piece move(String fromStr, String toStr, Typ type) {
+	public Piece move(String fromStr, String toStr, Typ promotionType) {
 		Board board = getBoard();
-
 		Square from = board.getSquare(fromStr);
 		Square to = board.getSquare(toStr);
-
-		return move(from, to, type);
+		return move(from, to, promotionType);
 	}
 
-	public Piece move(Square from, Square to, Typ type) {
+	public Piece move(Square from, Square to, Typ promotionType) {
 		if (!from.isOccupied())
 			throw new UnoccupiedSquareException(from);
 
@@ -127,11 +125,11 @@ public class Game {
 				((Pawn) piece).setEnPassant(true);
 
 			// Promotion
-			else if (type != null) {
+			else if (promotionType != null) {
 				char toFile = to.getFile();
 				int toRank = to.getRank();
 
-				switch (type) {
+				switch (promotionType) {
 				case KNIGHT:
 					promotedPiece = new Knight(getCurrentPlayer(), toFile, toRank);
 					break;
@@ -145,7 +143,7 @@ public class Game {
 					promotedPiece = new Queen(getCurrentPlayer(), toFile, toRank);
 					break;
 				default:
-					promotedPiece = null;
+					throw new RuntimeException("Cannot promote to a piece of type '" + promotionType + "'.");
 				}
 
 				newBoard.getSquare(toFile, toRank).setPiece(promotedPiece);

--- a/bishopsGambit/src/gui/ChessGUI.java
+++ b/bishopsGambit/src/gui/ChessGUI.java
@@ -85,6 +85,10 @@ public class ChessGUI extends JFrame {
 		return squareBtns.get(square.getIndex());
 	}
 
+	private SquareButton getSquareButton(Board board, Piece piece) {
+		return getSquareButton(piece.getSquare(board));
+	}
+
 	private void updateBoardMap() {
 		Board board;
 		if (to == null)
@@ -95,7 +99,7 @@ public class ChessGUI extends JFrame {
 		for (PieceLabel pieceLbl : pieceLbls) {
 			Piece piece = pieceLbl.getPiece();
 			if (board.containsPiece(piece))
-				boardMap.put(pieceLbl, getSquareButton(piece.getSquare(board)));
+				boardMap.put(pieceLbl, getSquareButton(board, piece));
 			else
 				boardMap.put(pieceLbl, null);
 		}
@@ -111,7 +115,7 @@ public class ChessGUI extends JFrame {
 	 * Returns the player whose turn it currently is, based on the number of turns
 	 * taken.
 	 * 
-	 * @return White if the number of turns taken is even, Black if it is odd
+	 * @return White if the number of turns taken is even; Black if it is odd
 	 */
 	private Player getCurrentPlayer() {
 		return getGame().getCurrentPlayer();
@@ -121,7 +125,7 @@ public class ChessGUI extends JFrame {
 	 * Returns the opponent of the player whose turn it currently is, based on the
 	 * number of turns taken.
 	 * 
-	 * @return Black if the number of turns taken is even, White if it is odd
+	 * @return Black if the number of turns taken is even; White if it is odd
 	 */
 	private Player getCurrentOpponent() {
 		return getGame().getCurrentOpponent();
@@ -132,8 +136,8 @@ public class ChessGUI extends JFrame {
 	}
 	// ---------------------------------------------------------------- //
 
-	private void addToLayer(JComponent comp, int layer) {
-		contentPane.add(comp, layer, 0);
+	private void addToLayer(JComponent component, int layer) {
+		contentPane.add(component, layer, 0);
 	}
 
 	private void createPieceLabel(Piece piece) {
@@ -263,7 +267,7 @@ public class ChessGUI extends JFrame {
 				Square fromSquare = getSquare(from);
 				Square toSquare = getSquare(to);
 
-				Typ type = null;
+				Typ promotionType = null;
 
 				if (fromSquare.getPiece().canPromote(getBoard(), toSquare)) {
 					Typ[] options = new Typ[] { Typ.KNIGHT, Typ.BISHOP, Typ.ROOK, Typ.QUEEN };
@@ -272,12 +276,12 @@ public class ChessGUI extends JFrame {
 							JOptionPane.DEFAULT_OPTION, JOptionPane.PLAIN_MESSAGE, to.getIcon(), options, null);
 
 					if (i == JOptionPane.CLOSED_OPTION)
-						type = Typ.QUEEN;
+						promotionType = Typ.QUEEN;
 					else
-						type = options[i];
+						promotionType = options[i];
 				}
 
-				Piece promotedPiece = game.move(fromSquare, toSquare, type);
+				Piece promotedPiece = game.move(fromSquare, toSquare, promotionType);
 
 				if (promotedPiece != null)
 					createPieceLabel(promotedPiece);
@@ -295,7 +299,7 @@ public class ChessGUI extends JFrame {
 
 				Player currentPlayer = getCurrentPlayer();
 				inCheck = currentPlayer.inCheck(getBoard());
-				kingSquareBtn = getSquareButton(currentPlayer.getKing().getSquare(getBoard()));
+				kingSquareBtn = getSquareButton(getBoard(), currentPlayer.getKing());
 
 				if (currentPlayer.noLegalMoves(getBoard())) {
 					String message;

--- a/bishopsGambit/src/pieces/King.java
+++ b/bishopsGambit/src/pieces/King.java
@@ -45,21 +45,21 @@ public class King extends Piece {
 	public List<Square> getMoves(Board board) {
 		List<Square> moves = new ArrayList<>(super.getMoves(board));
 
-		for (int x : new int[] { -1, 1 }) {
-			if (!hasMoved() && !isTargeted(board)) {
+		if (!hasMoved() && !isTargeted(board)) {
+			for (int x : new int[] { -1, 1 }) {
 				Rook rook = getPlayer().getRook(x);
 
 				if (!rook.hasMoved() && !rook.isCaptured()) {
-					Square s = getStartSquare(board);
+					Square k = getStartSquare(board);
+					Square r = rook.getStartSquare(board);
 
-					Square s1 = s.travel(board, x, 0); // Rook moves to
-					Square s2 = s.travel(board, 2 * x, 0); // King moves to
+					Square k1 = k.travel(board, x, 0); // One square adjacent to king (rook moves here)
+					Square k2 = k.travel(board, 2 * x, 0); // Two squares adjacent to king (king moves here)
+					Square r1 = r.travel(board, -x, 0); // One square adjacent to rook (same as 'k2' on kingside)
 
-					Board b1 = board.move(s, s1);
-					Board b2 = board.move(s, s2);
-
-					if (rook.isTargeting(board, s1) && !isTargeted(b1) && !isTargeted(b2))
-						moves.add(s2);
+					if (!k1.isOccupied() && !k2.isOccupied() && !r1.isOccupied() && !k1.isTargeted(board, getPlayer())
+							&& !k2.isTargeted(board, getPlayer()))
+						moves.add(k2);
 				}
 			}
 		}

--- a/bishopsGambit/src/pieces/Piece.java
+++ b/bishopsGambit/src/pieces/Piece.java
@@ -112,7 +112,7 @@ public abstract class Piece {
 	 * Finds the square this piece is occupying.
 	 * 
 	 * @param board the chess board
-	 * @return the square this piece is occupying (if it exists), {@code null}
+	 * @return the square this piece is occupying (if it exists); {@code null}
 	 *         otherwise
 	 */
 	public Square getSquare(Board board) {
@@ -124,10 +124,10 @@ public abstract class Piece {
 	 * piece is being targeted by an enemy piece.
 	 * 
 	 * @param board the chess board
-	 * @return {@code true} if this piece is being targeted, {@code false} otherwise
+	 * @return {@code true} if this piece is being targeted; {@code false} otherwise
 	 */
 	public boolean isTargeted(Board board) {
-		return getSquare(board).isTargeted(board);
+		return getSquare(board).isTargeted(board, getPlayer());
 	}
 
 	/**
@@ -136,7 +136,7 @@ public abstract class Piece {
 	 * 
 	 * @param board  the chess board
 	 * @param square the square
-	 * @return {@code true} if this piece is targeting the given square,
+	 * @return {@code true} if this piece is targeting the given square;
 	 *         {@code false} otherwise
 	 */
 	public boolean isTargeting(Board board, Square square) {

--- a/bishopsGambit/src/players/Player.java
+++ b/bishopsGambit/src/players/Player.java
@@ -36,7 +36,7 @@ public class Player {
 			pawnRank = 7;
 			break;
 		default:
-			throw new IllegalArgumentException("Colour must be either 'WHITE' or 'BLACK'");
+			throw new IllegalArgumentException("Colour must be either 'WHITE' or 'BLACK'.");
 		}
 
 		this.colour = colour;
@@ -107,7 +107,7 @@ public class Player {
 	 * in check.
 	 * 
 	 * @param board the chess board
-	 * @return {@code true} if this player's king is currently in check,
+	 * @return {@code true} if this player's king is currently in check;
 	 *         {@code false} otherwise
 	 */
 	public boolean inCheck(Board board) {
@@ -119,7 +119,7 @@ public class Player {
 	 * checkmate.
 	 * 
 	 * @param board the chess board
-	 * @return {@code true} if this player is currently in checkmate, {@code false}
+	 * @return {@code true} if this player is currently in checkmate; {@code false}
 	 *         otherwise
 	 */
 	public boolean inCheckmate(Board board) {
@@ -131,7 +131,7 @@ public class Player {
 	 * stalemate.
 	 * 
 	 * @param board the chess board
-	 * @return {@code true} if this player is currently in stalemate, {@code false}
+	 * @return {@code true} if this player is currently in stalemate; {@code false}
 	 *         otherwise
 	 */
 	public boolean inStalemate(Board board) {
@@ -146,11 +146,9 @@ public class Player {
 	 */
 	public int numberOfLegalMoves(Board board) {
 		int numberOfMoves = 0;
-
 		for (Piece piece : getPieces())
 			if (!piece.isCaptured())
 				numberOfMoves += piece.getMoves(board).size();
-
 		return numberOfMoves;
 	}
 
@@ -158,7 +156,7 @@ public class Player {
 	 * Returns a boolean indicating whether or not this player has any legal moves.
 	 * 
 	 * @param board the chess board
-	 * @return {@code true} if this player has no legal moves, {@code false}
+	 * @return {@code true} if this player has no legal moves; {@code false}
 	 *         otherwise
 	 */
 	public boolean noLegalMoves(Board board) {

--- a/bishopsGambit/src/test/ChessTest.java
+++ b/bishopsGambit/src/test/ChessTest.java
@@ -1,6 +1,7 @@
 package test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
@@ -9,6 +10,8 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInfo;
 
+import board.Board;
+import board.Square;
 import core.Game;
 import core.IllegalMoveException;
 import core.UnoccupiedSquareException;
@@ -40,8 +43,20 @@ class ChessTest {
 		return game.getBlack();
 	}
 
+	Board getBoard() {
+		return game.getBoard();
+	}
+
+	Square getSquare(String squareStr) {
+		return getBoard().getSquare(squareStr);
+	}
+
 	Piece getPiece(String squareStr) {
-		return game.getBoard().getSquare(squareStr).getPiece();
+		return getSquare(squareStr).getPiece();
+	}
+
+	boolean canMoveTo(Piece piece, String squareStr) {
+		return piece.getMoves(getBoard()).contains(getSquare(squareStr));
 	}
 
 	int numberOfTurnsTaken() {
@@ -72,7 +87,7 @@ class ChessTest {
 
 	@AfterEach
 	void printBoard() {
-		game.getBoard().print();
+		getBoard().print();
 	}
 
 	@Test
@@ -196,6 +211,41 @@ class ChessTest {
 
 		assertEquals(numberOfTurnsTaken(), 10);
 		assertEquals(numberOfLegalMoves(), 1);
+	}
+
+	@Test
+	void enemyKnightBlocksKingsideCastling() {
+		move(E2, E4);
+		move(G8, F6);
+
+		move(G1, F3);
+		move(F6, G4);
+
+		move(F1, C4);
+		move(G4, E3);
+
+		move(D2, D3);
+		move(E3, F1);
+
+		assertEquals(numberOfTurnsTaken(), 8);
+
+		assertFalse(canMoveTo(getWhite().getKing(), G1));
+	}
+
+	@Test
+	void enemyBishopBlocksKingsideCastling() {
+		move(E2, E4);
+		move(B7, B6);
+
+		move(G1, F3);
+		move(C8, A6);
+
+		move(D2, D4);
+		move(A6, F1);
+
+		assertEquals(numberOfTurnsTaken(), 6);
+
+		assertFalse(canMoveTo(getWhite().getKing(), G1));
 	}
 
 }

--- a/bishopsGambit/src/utils/ListUtils.java
+++ b/bishopsGambit/src/utils/ListUtils.java
@@ -23,7 +23,7 @@ public class ListUtils {
 	 * @param list2  the list containing the given <b>object</b>
 	 * @param object the object whose index we are interested in
 	 * @return the element in <b>list1</b> that has the same index as the given
-	 *         <b>object</b> in <b>list2</b> (if it exists), {@code null} otherwise
+	 *         <b>object</b> in <b>list2</b> (if it exists); {@code null} otherwise
 	 */
 	public static <T, U> T get(List<T> list1, List<U> list2, U object) {
 		int index = list2.indexOf(object);


### PR DESCRIPTION
This issue was occurring because of the code in `King::getMoves`.

<img width=66% alt="King getMoves" src="https://github.com/OllyBishop/bishopsGambit/assets/21021117/279ad70e-74f8-440e-a6dc-7383f3f9f0ce">

In the given scenarios, the rook is indeed targeting the square F1, but this is because it contains an enemy piece (namely the knight/bishop) rather than it being **unoccupied**. For castling to be allowed, all squares between the king and rook must be unoccupied, which is not the case here.

<img width=33% alt="Enemy knight DOESN'T block castling when occupying middle square" src="https://github.com/OllyBishop/bishopsGambit/assets/21021117/51c5df32-b5b8-4960-bac1-5898f15c5fc7">

<img width=33% alt="Enemy bishop DOESN'T block castling when occupying middle square" src="https://github.com/OllyBishop/bishopsGambit/assets/21021117/db7d7bca-d17f-427b-a5f5-83c976fee618">

I've corrected this logic by requiring that each square in between the king and rook (`k1`, `k2` and `r1`) is **unoccupied** for castling to be allowed. I also added two test cases to cover the given scenarios.

As we can see, the enemy knight/bishop now correctly blocks the king from castling to G1.

<img width=33% alt="Knight blocks castling" src="https://github.com/OllyBishop/bishopsGambit/assets/21021117/b473daf3-5eb8-4d90-b218-fef02e05b164">

<img width=33% alt="Bishop blocks castling" src="https://github.com/OllyBishop/bishopsGambit/assets/21021117/cdeeab9c-fe80-4d6d-a8bd-4b16ba1f59f6">