### PR TITLE
BG-9 - Ensure PieceLabels are created with a non-zero width and height

### DIFF
--- a/bishopsGambit/src/main/java/gui/GUI.java
+++ b/bishopsGambit/src/main/java/gui/GUI.java
@@ -154,6 +154,7 @@ public class GUI extends JFrame
     private void createPieceLabel( Piece piece )
     {
         PieceLabel pieceLbl = new PieceLabel( piece );
+        pieceLbl.setSize( scale, scale );
         pieceLbls.add( pieceLbl );
         addToLayer( pieceLbl, PIECE_LAYER );
     }


### PR DESCRIPTION
When a new PieceLabel is created, it is now immediately assigned a non-zero width and height. This ensure the piece always renders when it is added to the board (i.e. as a result of pawn promotion).

### Before
<img width=24% src="https://github.com/OllyBishop/bishopsGambit/assets/21021117/7be2d3e1-9b4f-4a2a-a2fa-69dd1867d6b2">
<img width=24% src="https://github.com/OllyBishop/bishopsGambit/assets/21021117/61dc8052-5816-472e-9852-303a2d5a2801">
<img width=24% src="https://github.com/OllyBishop/bishopsGambit/assets/21021117/6d6fe61a-d072-4fa0-8363-85b505c4de3a">
<img width=24% src="https://github.com/OllyBishop/bishopsGambit/assets/21021117/17278eb1-184b-49dd-8d1a-887663f1848e">

### After
<img width=33% src="https://github.com/OllyBishop/bishopsGambit/assets/21021117/7be2d3e1-9b4f-4a2a-a2fa-69dd1867d6b2">
<img width=33% src="https://github.com/OllyBishop/bishopsGambit/assets/21021117/61dc8052-5816-472e-9852-303a2d5a2801">
<img width=33% src="https://github.com/OllyBishop/bishopsGambit/assets/21021117/7347c13b-7fcf-4472-bf71-3b98defbb645">