### PR TITLE
BG-12 - Display captured pieces next to the board

### DIFF
--- a/bishopsGambit/src/main/java/Orderable.java
+++ b/bishopsGambit/src/main/java/Orderable.java
@@ -1,0 +1,6 @@
+package main.java;
+
+public interface Orderable extends Comparable<Object>
+{
+    int getOrder();
+}

--- a/bishopsGambit/src/main/java/game/Game.java
+++ b/bishopsGambit/src/main/java/game/Game.java
@@ -53,13 +53,13 @@ public class Game
 
     private void printInfo( Board board )
     {
-        Player currentPlayer = getCurrentPlayer();
-        int n = currentPlayer.numberOfLegalMoves( board );
+        Player activePlayer = getActivePlayer();
+        int n = activePlayer.numberOfLegalMoves( board );
 
         if ( n == 1 )
-            System.out.printf( "%s has 1 legal move.", currentPlayer );
+            System.out.printf( "%s has 1 legal move.", activePlayer );
         else
-            System.out.printf( "%s has %d legal moves.", currentPlayer, n );
+            System.out.printf( "%s has %d legal moves.", activePlayer, n );
 
         int diff = board.getMaterialDiff();
 
@@ -84,7 +84,7 @@ public class Game
      * 
      * @return White if the number of turns taken is even; Black if it is odd
      */
-    public Player getCurrentPlayer()
+    public Player getActivePlayer()
     {
         return numberOfTurnsTaken() % 2 == 0 ? getWhite() : getBlack();
     }
@@ -95,7 +95,7 @@ public class Game
      * 
      * @return Black if the number of turns taken is even; White if it is odd
      */
-    public Player getCurrentOpponent()
+    public Player getInactivePlayer()
     {
         return numberOfTurnsTaken() % 2 == 0 ? getBlack() : getWhite();
     }
@@ -123,11 +123,11 @@ public class Game
         if ( !board.isLegalMove( from, to ) )
             throw new IllegalMoveException( from, to );
 
-        // Disable en passant capture of opponent's pawns
-        getCurrentOpponent().getPieces()
-                            .stream()
-                            .filter( pc -> pc instanceof Pawn )
-                            .forEach( pc -> ((Pawn) pc).setEnPassant( false ) );
+        // Disable en passant capture of enemy pawns
+        getInactivePlayer().getPieces()
+                           .stream()
+                           .filter( pc -> pc instanceof Pawn )
+                           .forEach( pc -> ((Pawn) pc).setEnPassant( false ) );
 
         Piece piece = from.getPiece();
         Board newBoard = board.move( from, to );
@@ -151,19 +151,19 @@ public class Game
                 switch ( promType )
                 {
                     case KNIGHT:
-                        promPiece = new Knight( getCurrentPlayer(), toFile, toRank );
+                        promPiece = new Knight( getActivePlayer(), toFile, toRank );
                         break;
 
                     case BISHOP:
-                        promPiece = new Bishop( getCurrentPlayer(), toFile, toRank );
+                        promPiece = new Bishop( getActivePlayer(), toFile, toRank );
                         break;
 
                     case ROOK:
-                        promPiece = new Rook( getCurrentPlayer(), toFile, toRank );
+                        promPiece = new Rook( getActivePlayer(), toFile, toRank );
                         break;
 
                     case QUEEN:
-                        promPiece = new Queen( getCurrentPlayer(), toFile, toRank );
+                        promPiece = new Queen( getActivePlayer(), toFile, toRank );
                         break;
 
                     default:

--- a/bishopsGambit/src/main/java/gui/OrderedJPanel.java
+++ b/bishopsGambit/src/main/java/gui/OrderedJPanel.java
@@ -1,0 +1,52 @@
+package main.java.gui;
+
+import java.awt.Component;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+import javax.swing.JPanel;
+
+import main.java.Orderable;
+
+public class OrderedJPanel extends JPanel
+{
+    private final List<Orderable> orderedList = new ArrayList<>();
+
+    @Override
+    protected void addImpl( Component comp, Object constraints, int index )
+    {
+        addImpl( comp, constraints );
+    }
+
+    private void addImpl( Component comp, Object constraints )
+    {
+        if ( !(comp instanceof Orderable) )
+            throw new IllegalArgumentException( "The component being added must be an instance of Orderable." );
+
+        // Find the component next to which the new component should be inserted
+        Optional<Orderable> optional = orderedList.stream()
+                                                  .filter( o -> o.compareTo( comp ) >= 0 )
+                                                  .findFirst();
+
+        if ( optional.isPresent() )
+        {
+            int index = orderedList.indexOf( optional.get() );
+
+            super.addImpl( comp, constraints, index );
+            orderedList.add( index, (Orderable) comp );
+        }
+        else
+        {
+            super.addImpl( comp, constraints, -1 );
+            orderedList.add( (Orderable) comp );
+        }
+    }
+
+    @Override
+    public void remove( int index )
+    {
+        super.remove( index );
+        orderedList.remove( index );
+    }
+}

--- a/bishopsGambit/src/main/java/gui/PieceComp.java
+++ b/bishopsGambit/src/main/java/gui/PieceComp.java
@@ -5,10 +5,11 @@ import java.awt.Image;
 import javax.swing.ImageIcon;
 import javax.swing.JLabel;
 
-import main.java.io.Graphics;
+import main.java.Orderable;
+import main.java.io.Images;
 import main.java.pieces.Piece;
 
-public class PieceComp extends JLabel
+public class PieceComp extends JLabel implements Orderable
 {
     private final Piece piece;
 
@@ -25,13 +26,24 @@ public class PieceComp extends JLabel
     public void setScale( int scale )
     {
         setSize( scale, scale );
-        paintIcon();
+
+        Image imageFull = Images.getImage( getPiece() );
+        Image imageScaled = imageFull.getScaledInstance( scale, scale, Image.SCALE_SMOOTH );
+        setIcon( new ImageIcon( imageScaled ) );
     }
 
-    private void paintIcon()
+    @Override
+    public int compareTo( Object o )
     {
-        Image imageFull = Graphics.getImage( getPiece() );
-        Image imageScaled = imageFull.getScaledInstance( getWidth(), getHeight(), Image.SCALE_SMOOTH );
-        setIcon( new ImageIcon( imageScaled ) );
+        if ( !(o instanceof PieceComp) )
+            throw new RuntimeException( "The object being compared must be an instance of PieceComp." );
+
+        return Integer.compare( getOrder(), ((PieceComp) o).getOrder() );
+    }
+
+    @Override
+    public int getOrder()
+    {
+        return getPiece().getType().ordinal();
     }
 }

--- a/bishopsGambit/src/main/java/gui/SquareComp.java
+++ b/bishopsGambit/src/main/java/gui/SquareComp.java
@@ -2,9 +2,9 @@ package main.java.gui;
 
 import java.awt.Color;
 import java.awt.Dimension;
+import java.awt.Font;
 import java.awt.Graphics;
 
-import javax.swing.Icon;
 import javax.swing.JComponent;
 import javax.swing.JLabel;
 import javax.swing.JLayeredPane;
@@ -12,6 +12,7 @@ import javax.swing.SwingConstants;
 
 import main.java.board.Square;
 import main.java.io.Fonts;
+import main.java.io.Fonts.Weight;
 import main.java.util.ColorUtils;
 import main.java.util.ComponentUtils;
 
@@ -20,6 +21,8 @@ public class SquareComp extends JLayeredPane
     private static final Color DARK = new Color( 209, 139, 71 );
     private static final Color LIGHT = new Color( 254, 206, 157 );
     private static final Color HIGHLIGHT = ColorUtils.blend( Color.yellow, Color.white );
+
+    private static final Font ROBOTO_MEDIUM = Fonts.importFont( "Roboto", Weight.MEDIUM );
 
     /*
      * New squares are created throughout the game, but the file and rank of a given square never
@@ -35,8 +38,6 @@ public class SquareComp extends JLayeredPane
     private final JLabel fileLbl;
     private final JLabel rankLbl;
     private final CircleComp circleComp;
-
-    private PieceComp pieceComp;
 
     public char getFile()
     {
@@ -65,13 +66,13 @@ public class SquareComp extends JLayeredPane
         fileLbl.setVerticalAlignment( SwingConstants.BOTTOM );
         fileLbl.setHorizontalAlignment( SwingConstants.RIGHT );
         fileLbl.setForeground( defaultFg );
-        fileLbl.setFont( Fonts.ROBOTO_MEDIUM );
+        fileLbl.setFont( ROBOTO_MEDIUM );
 
         this.rankLbl = new JLabel( String.valueOf( rank ) );
         rankLbl.setVerticalAlignment( SwingConstants.TOP );
         rankLbl.setHorizontalAlignment( SwingConstants.LEFT );
         rankLbl.setForeground( defaultFg );
-        rankLbl.setFont( Fonts.ROBOTO_MEDIUM );
+        rankLbl.setFont( ROBOTO_MEDIUM );
 
         this.circleComp = new CircleComp();
 
@@ -85,9 +86,15 @@ public class SquareComp extends JLayeredPane
         setOpaque( true );
     }
 
-    public void add( PieceComp pieceComp )
+    public void addPieceComp( PieceComp pieceComp )
     {
         add( pieceComp, PALETTE_LAYER );
+
+        /*
+         * Necessary to prevent UI issues. The selected piece may be positioned outside the bounds of
+         * the square it occupies when a move preview is undone.
+         */
+        pieceComp.setLocation( 0, 0 );
     }
 
     private void resetBackground()
@@ -151,17 +158,6 @@ public class SquareComp extends JLayeredPane
 
         ComponentUtils.resizeFont( fileLbl, scale / 5 );
         ComponentUtils.resizeFont( rankLbl, scale / 5 );
-
-        if ( pieceComp != null )
-            pieceComp.setScale( scale );
-    }
-
-    public Icon getIcon()
-    {
-        if ( pieceComp != null )
-            return pieceComp.getIcon();
-
-        return null;
     }
 
     public int getIndex()
@@ -179,7 +175,7 @@ public class SquareComp extends JLayeredPane
         }
 
         @Override
-        public void paintComponent( Graphics g )
+        protected void paintComponent( Graphics g )
         {
             super.paintComponent( g );
 

--- a/bishopsGambit/src/main/java/io/Fonts.java
+++ b/bishopsGambit/src/main/java/io/Fonts.java
@@ -10,9 +10,7 @@ import java.util.List;
 
 public class Fonts
 {
-    public static final Font ROBOTO_MEDIUM = importFont( "Roboto", Weight.MEDIUM );
-
-    private static Font importFont( String name, Weight weight )
+    public static Font importFont( String name, Weight weight )
     {
         Font font = null;
 
@@ -52,17 +50,17 @@ public class Fonts
         BOLD_ITALIC( "BoldItalic" ),
         BLACK_ITALIC( "BlackItalic" );
 
-        private final String value;
+        private final String str;
 
-        Weight( String value )
+        Weight( String str )
         {
-            this.value = value;
+            this.str = str;
         }
 
         @Override
         public String toString()
         {
-            return this.value;
+            return this.str;
         }
     }
 }

--- a/bishopsGambit/src/main/java/io/Images.java
+++ b/bishopsGambit/src/main/java/io/Images.java
@@ -4,12 +4,14 @@ import java.awt.Image;
 import java.io.IOException;
 
 import javax.imageio.ImageIO;
+import javax.swing.Icon;
+import javax.swing.ImageIcon;
 
 import main.java.pieces.Piece;
 import main.java.pieces.Piece.Typ;
 import main.java.player.Player.Colour;
 
-public class Graphics
+public class Images
 {
     private static Image whitePawn = importImage( Colour.WHITE, Typ.PAWN );
     private static Image whiteKnight = importImage( Colour.WHITE, Typ.KNIGHT );
@@ -32,7 +34,7 @@ public class Graphics
         try
         {
             String imagePath = String.format( "/main/resources/img/%s_%s.png", colour, type );
-            image = ImageIO.read( Graphics.class.getResource( imagePath ) );
+            image = ImageIO.read( Images.class.getResource( imagePath ) );
         }
         catch ( IOException e )
         {
@@ -71,5 +73,10 @@ public class Graphics
                 case KING -> blackKing;
             };
         };
+    }
+
+    public static Icon getIcon( Colour colour, Typ type )
+    {
+        return new ImageIcon( getImage( colour, type ) );
     }
 }

--- a/bishopsGambit/src/main/java/pieces/Piece.java
+++ b/bishopsGambit/src/main/java/pieces/Piece.java
@@ -193,23 +193,23 @@ public abstract class Piece
     public enum Typ
     {
         KING( "King" ),
-        QUEEN( "Queen" ),
-        ROOK( "Rook" ),
-        BISHOP( "Bishop" ),
+        PAWN( "Pawn" ),
         KNIGHT( "Knight" ),
-        PAWN( "Pawn" );
+        BISHOP( "Bishop" ),
+        ROOK( "Rook" ),
+        QUEEN( "Queen" );
 
-        private final String value;
+        private final String str;
 
-        Typ( String value )
+        Typ( String str )
         {
-            this.value = value;
+            this.str = str;
         }
 
         @Override
         public String toString()
         {
-            return this.value;
+            return this.str;
         }
     }
 }

--- a/bishopsGambit/src/main/java/player/Player.java
+++ b/bishopsGambit/src/main/java/player/Player.java
@@ -188,17 +188,17 @@ public class Player
         WHITE( "White" ),
         BLACK( "Black" );
 
-        private final String value;
+        private final String str;
 
-        Colour( String value )
+        Colour( String str )
         {
-            this.value = value;
+            this.str = str;
         }
 
         @Override
         public String toString()
         {
-            return this.value;
+            return this.str;
         }
     }
 }

--- a/bishopsGambit/src/test/java/game/GameTest.java
+++ b/bishopsGambit/src/test/java/game/GameTest.java
@@ -73,17 +73,17 @@ class GameTest
 
     int numberOfLegalMoves()
     {
-        return game.getCurrentPlayer().numberOfLegalMoves( game.getBoard() );
+        return game.getActivePlayer().numberOfLegalMoves( game.getBoard() );
     }
 
     boolean checkmate()
     {
-        return game.getCurrentPlayer().isInCheckmate( game.getBoard() );
+        return game.getActivePlayer().isInCheckmate( game.getBoard() );
     }
 
     boolean stalemate()
     {
-        return game.getCurrentPlayer().isInStalemate( game.getBoard() );
+        return game.getActivePlayer().isInStalemate( game.getBoard() );
     }
 
     @BeforeEach


### PR DESCRIPTION
- Added JPanels (one each for White/Black) to display captured pieces
  - When a piece is captured, it is moved to one of these JPanels
  - The JPanel depends on the colour of the piece captured
  - Each JPanel is displayed below the capturing player's back rank
  - Captured pieces are ordered according to their value

- Created new interface Orderable (extends Comparable)
  - Implemented interface in class PieceComp

- Created new class OrderedJPanel (extends JPanel)
  - Components added must implement Orderable
  - Components are positioned in an order deemed by Orderable::getOrder

- Renamed Graphics.java to Images.java

<img width=49% alt="Captured pieces" src="https://github.com/user-attachments/assets/a0594820-b836-4581-8575-99d5dbcb898f">