### PR TITLE
BG-14 - Added top and bottom menu bars to GUI

### DIFF
--- a/bishopsGambit/src/main/java/game/Game.java
+++ b/bishopsGambit/src/main/java/game/Game.java
@@ -42,6 +42,13 @@ public class Game
         addBoard( board );
     }
 
+    /**
+     * This method is called whenever a move is made. By storing a list of board states throughout
+     * the game, we can view how the board looked on a previous turn and (potentially) undo moves.
+     * The number of boards stored is used to determine which player's turn it is.
+     * 
+     * @param board the new {@code Board} after a move was made
+     */
     private void addBoard( Board board )
     {
         boards.add( board );
@@ -148,7 +155,7 @@ public class Game
 
     /**
      * @param uci a string representing the move in Universal Chess Interface (UCI) notation
-     * @return the promoted piece (if applicable); otherwise {@code null}
+     * @return the promoted piece (if applicable); {@code null} otherwise
      */
     public Piece makeMove( String uci )
     {

--- a/bishopsGambit/src/main/java/gui/GUI.java
+++ b/bishopsGambit/src/main/java/gui/GUI.java
@@ -18,9 +18,11 @@ import java.util.List;
 
 import javax.swing.BorderFactory;
 import javax.swing.Icon;
+import javax.swing.JButton;
 import javax.swing.JFrame;
 import javax.swing.JOptionPane;
 import javax.swing.JPanel;
+import javax.swing.JToggleButton;
 
 import main.java.board.Board;
 import main.java.board.Square;
@@ -30,16 +32,36 @@ import main.java.io.Images;
 import main.java.pieces.Piece;
 import main.java.pieces.Piece.Typ;
 import main.java.player.Player;
+import main.java.player.Player.Colour;
 
 public class GUI extends JFrame
 {
     // ============================================================================================
-    // Instance Variables
+    // Components and Layouts
     // ============================================================================================
 
+    // Content Pane
+
     private final JPanel contentPane = new JPanel();
-    private final BorderLayout contentLayoutWhite = new BorderLayout();
-    private final BorderLayout contentLayoutBlack = new BorderLayout();
+    private final BorderLayout contentLayout = new BorderLayout();
+
+    // Menus and Menu Buttons
+
+    private final JPanel topMenuPane = new JPanel();
+    private final JPanel bottomMenuPane = new JPanel();
+
+    private final JButton newGameButton = new JButton( "New Game" );
+    private final JButton flipBoardButton = new JButton( "Flip Board" );
+    private final JToggleButton lockBoardButton = new JToggleButton( "Lock Board" );
+
+    private final JButton previousMoveButton = new JButton( "Previous Move" );
+    private final JButton nextMoveButton = new JButton( "Next Move" );
+
+    // Tabletop, Chessboard and Captured Pieces
+
+    private final JPanel tabletopPane = new JPanel();
+    private final BorderLayout tabletopLayoutWhite = new BorderLayout();
+    private final BorderLayout tabletopLayoutBlack = new BorderLayout();
 
     private final JPanel chessboardPane = new JPanel();
     private final GridBagLayout chessboardLayoutWhite = new GridBagLayout();
@@ -50,6 +72,8 @@ public class GUI extends JFrame
     private final FlowLayout capturedPiecesLayoutWhite = new FlowLayout();
     private final FlowLayout capturedPiecesLayoutBlack = new FlowLayout();
 
+    // Squares and Pieces
+
     private final List<SquareComp> squareComps = new ArrayList<>();
     private final List<PieceComp> pieceComps = new ArrayList<>();
 
@@ -57,11 +81,11 @@ public class GUI extends JFrame
     private SquareComp to;
     private SquareComp check;
 
-    private Game game;
+    // ============================================================================================
+    // Non-Component Fields
+    // ============================================================================================
 
-    // ============================================================================================
-    // Getters and Setters
-    // ============================================================================================
+    private Game game;
 
     private Game getGame()
     {
@@ -147,6 +171,7 @@ public class GUI extends JFrame
         createLayouts();
 
         addSquareClickedListeners();
+        addMenuButtonClickedListeners();
         addKeyPressedListener();
         addFrameResizedListener();
 
@@ -171,9 +196,21 @@ public class GUI extends JFrame
     private void addComponentsToFrame()
     {
         add( contentPane );
-        contentPane.add( chessboardPane );
-        contentPane.add( capturedPiecesPaneWhite );
-        contentPane.add( capturedPiecesPaneBlack );
+
+        contentPane.add( tabletopPane );
+        contentPane.add( topMenuPane );
+        contentPane.add( bottomMenuPane );
+
+        topMenuPane.add( newGameButton );
+        topMenuPane.add( flipBoardButton );
+        topMenuPane.add( lockBoardButton );
+
+        bottomMenuPane.add( previousMoveButton );
+        bottomMenuPane.add( nextMoveButton );
+
+        tabletopPane.add( chessboardPane );
+        tabletopPane.add( capturedPiecesPaneWhite );
+        tabletopPane.add( capturedPiecesPaneBlack );
 
         for ( SquareComp squareComp : squareComps )
             chessboardPane.add( squareComp );
@@ -181,13 +218,17 @@ public class GUI extends JFrame
 
     private void createLayouts()
     {
-        contentLayoutWhite.addLayoutComponent( chessboardPane, BorderLayout.CENTER );
-        contentLayoutWhite.addLayoutComponent( capturedPiecesPaneWhite, BorderLayout.NORTH );
-        contentLayoutWhite.addLayoutComponent( capturedPiecesPaneBlack, BorderLayout.SOUTH );
+        contentLayout.addLayoutComponent( tabletopPane, BorderLayout.CENTER );
+        contentLayout.addLayoutComponent( topMenuPane, BorderLayout.NORTH );
+        contentLayout.addLayoutComponent( bottomMenuPane, BorderLayout.SOUTH );
 
-        contentLayoutBlack.addLayoutComponent( chessboardPane, BorderLayout.CENTER );
-        contentLayoutBlack.addLayoutComponent( capturedPiecesPaneWhite, BorderLayout.SOUTH );
-        contentLayoutBlack.addLayoutComponent( capturedPiecesPaneBlack, BorderLayout.NORTH );
+        tabletopLayoutWhite.addLayoutComponent( chessboardPane, BorderLayout.CENTER );
+        tabletopLayoutWhite.addLayoutComponent( capturedPiecesPaneWhite, BorderLayout.NORTH );
+        tabletopLayoutWhite.addLayoutComponent( capturedPiecesPaneBlack, BorderLayout.SOUTH );
+
+        tabletopLayoutBlack.addLayoutComponent( chessboardPane, BorderLayout.CENTER );
+        tabletopLayoutBlack.addLayoutComponent( capturedPiecesPaneWhite, BorderLayout.SOUTH );
+        tabletopLayoutBlack.addLayoutComponent( capturedPiecesPaneBlack, BorderLayout.NORTH );
 
         for ( SquareComp squareComp : squareComps )
         {
@@ -207,6 +248,8 @@ public class GUI extends JFrame
             chessboardLayoutBlack.setConstraints( squareComp, chessboardConstraintsBlack );
         }
 
+        contentPane.setLayout( contentLayout );
+
         capturedPiecesPaneWhite.setLayout( capturedPiecesLayoutWhite );
         capturedPiecesPaneBlack.setLayout( capturedPiecesLayoutBlack );
     }
@@ -221,10 +264,42 @@ public class GUI extends JFrame
                 public void mouseReleased( MouseEvent e )
                 {
                     if ( squareComp.contains( e.getPoint() ) )
-                        doClickAction( squareComp );
+                        doSquareClickedAction( squareComp );
                 }
             } );
         }
+    }
+
+    private void addMenuButtonClickedListeners()
+    {
+        newGameButton.addMouseListener( new MouseAdapter()
+        {
+            @Override
+            public void mouseReleased( MouseEvent e )
+            {
+                int i = JOptionPane.showConfirmDialog( rootPane,
+                                                       "Are you sure you want to start a new game?",
+                                                       "New Game",
+                                                       JOptionPane.YES_NO_OPTION );
+
+                if ( i == JOptionPane.YES_OPTION )
+                {
+                    // TODO
+                }
+            }
+        } );
+
+        flipBoardButton.addMouseListener( new MouseAdapter()
+        {
+            @Override
+            public void mouseReleased( MouseEvent e )
+            {
+                if ( tabletopPane.getLayout() == tabletopLayoutWhite )
+                    orientBoard( Colour.BLACK, true );
+                else
+                    orientBoard( Colour.WHITE, true );
+            }
+        } );
     }
 
     private void addKeyPressedListener()
@@ -271,7 +346,7 @@ public class GUI extends JFrame
     // Methods
     // ============================================================================================
 
-    private void doClickAction( SquareComp squareComp )
+    private void doSquareClickedAction( SquareComp squareComp )
     {
         if ( from != null && to == null )
             for ( SquareComp sqComp : squareComps )
@@ -332,10 +407,18 @@ public class GUI extends JFrame
 
     private void orientBoard()
     {
-        switch ( getActivePlayer().getColour() )
+        orientBoard( getActivePlayer().getColour(), false );
+    }
+
+    private void orientBoard( Colour colour, boolean bypassLock )
+    {
+        if ( !bypassLock && lockBoardButton.isSelected() )
+            return;
+
+        switch ( colour )
         {
             case WHITE:
-                contentPane.setLayout( contentLayoutWhite );
+                tabletopPane.setLayout( tabletopLayoutWhite );
                 chessboardPane.setLayout( chessboardLayoutWhite );
 
                 for ( SquareComp squareComp : squareComps )
@@ -347,7 +430,7 @@ public class GUI extends JFrame
                 break;
 
             case BLACK:
-                contentPane.setLayout( contentLayoutBlack );
+                tabletopPane.setLayout( tabletopLayoutBlack );
                 chessboardPane.setLayout( chessboardLayoutBlack );
 
                 for ( SquareComp squareComp : squareComps )
@@ -415,10 +498,7 @@ public class GUI extends JFrame
 
     private int getScale()
     {
-        int width = contentPane.getWidth();
-        int height = contentPane.getHeight();
-        int min = Math.min( width, height );
-
+        int min = Math.min( contentPane.getWidth(), contentPane.getHeight() );
         return Math.max( 10, min / 8 );
     }
 

--- a/bishopsGambit/src/main/java/gui/OrderedJPanel.java
+++ b/bishopsGambit/src/main/java/gui/OrderedJPanel.java
@@ -17,20 +17,15 @@ public class OrderedJPanel extends JPanel
         if ( !(comp instanceof Orderable) )
             throw new IllegalArgumentException( "The component being added must be an instance of Orderable." );
 
-        addImpl( comp, constraints );
-    }
-
-    private void addImpl( Component comp, Object constraints )
-    {
         List<Orderable> components = Arrays.stream( getComponents() )
                                            .map( c -> (Orderable) c )
                                            .toList();
 
         // Get the index of the component before which the new component should be inserted
-        int index = IntStream.range( 0, components.size() )
-                             .filter( i -> components.get( i ).compareTo( (Orderable) comp ) >= 0 )
-                             .findFirst()
-                             .orElse( -1 );
+        index = IntStream.range( 0, components.size() )
+                         .filter( i -> components.get( i ).compareTo( (Orderable) comp ) >= 0 )
+                         .findFirst()
+                         .orElse( -1 );
 
         super.addImpl( comp, constraints, index );
     }

--- a/bishopsGambit/src/main/java/pieces/Pawn.java
+++ b/bishopsGambit/src/main/java/pieces/Pawn.java
@@ -59,20 +59,15 @@ public class Pawn extends Piece
             Square s0 = square.travel( board, x, 0 );
             Square s1 = square.travel( board, x, y );
 
-            // Regular capture
-            if ( s1 != null && s1.isOccupiedByOpponent( getPlayer() ) )
-            {
-                targets.add( s1 );
-            }
+            boolean regularCapture = s1 != null &&
+                                     s1.isOccupiedByOpponent( getPlayer() );
 
-            // En passant capture
-            else if ( s0 != null && s0.isOccupiedByOpponent( getPlayer() ) )
-            {
-                if ( s0.getPiece() == board.getEnPassantPawn() )
-                {
-                    targets.add( s1 );
-                }
-            }
+            boolean enPassantCapture = s0 != null &&
+                                       s0.isOccupiedByOpponent( getPlayer() ) &&
+                                       s0.getPiece() == board.getEnPassantPawn();
+
+            if ( regularCapture || enPassantCapture )
+                targets.add( s1 );
         }
 
         return targets;


### PR DESCRIPTION
- Created new JPanel with BorderLayout to contain menus and tabletop
  - Set tabletop as center component
  - Set top menu as north component
  - Set bottom menu as south component

- Added **New Game**, **Flip Board** and **Lock Board** buttons to top menu
  - **New Game** functionality not yet implemented
  - **Flip Board** functionality implemented
  - **Lock Board** functionality implemented

- Added **Previous Move** and **Next Move** buttons to bottom menu
  - **Previous Move** functionality not yet implemented
  - **Next Move** functionality not yet implemented

Example of the **Flip Board** function, where White's move preview is shown from Black's perspective.
<img width=50% alt="'Flip Board' menu button" src="https://github.com/user-attachments/assets/9f97b6f3-5058-4327-b63e-1f419c935d0b" />