### PR TITLE
BG-17 - Implemented 'Previous Move' and 'Next Move' button functionality

### DIFF
--- a/bishopsGambit/src/main/java/board/Board.java
+++ b/bishopsGambit/src/main/java/board/Board.java
@@ -83,7 +83,7 @@ public class Board extends ArrayList<Square>
      * given piece is currently occupying any square on this board.
      * 
      * @param piece the piece
-     * @return a boolean indicating whether this board contains the given piece
+     * @return {@code true} if this board contains the given piece; {@code false} otherwise
      */
     public boolean containsPiece( Piece piece )
     {
@@ -127,6 +127,14 @@ public class Board extends ArrayList<Square>
         return 'a' <= file && file <= 'h' && '1' <= rank && rank <= '8';
     }
 
+    /**
+     * Moves the piece occupying the given <b>from</b> square to the given <b>to</b> square. Handles
+     * special moves (castling, en passant) by moving or removing the relevant piece (rook, pawn).
+     * 
+     * @param from the square containing the piece to be moved
+     * @param to   the destination square for the piece
+     * @return the new {@code Board} object
+     */
     public Board move( Square from, Square to )
     {
         Piece piece = from.getPiece();
@@ -159,7 +167,7 @@ public class Board extends ArrayList<Square>
         if ( to.isOccupied() && to.getPiece() instanceof Rook )
             newBoard.revokeCastlingRights( to.getPiece() );
 
-        newBoard.updateEnPassantPawn( piece, from, to );
+        newBoard.updateEnPassantPawn( from, to );
 
         return newBoard;
     }
@@ -194,8 +202,10 @@ public class Board extends ArrayList<Square>
         }
     }
 
-    private void updateEnPassantPawn( Piece piece, Square from, Square to )
+    private void updateEnPassantPawn( Square from, Square to )
     {
+        Piece piece = from.getPiece();
+
         if ( piece instanceof Pawn && piece.movedTwoSquaresForward( from, to ) )
             // Allow this pawn to be captured en passant on the next turn
             enPassantPawn = (Pawn) piece;
@@ -277,8 +287,8 @@ public class Board extends ArrayList<Square>
 
     private static class Printer
     {
-        // For each box drawing char below, n is the number of "prongs" that char has
-        // To convert box drawing chars from light to heavy, add (1 << n) - 1 to each
+        // For each box-drawing char below, n is the number of "prongs" that char has.
+        // To convert box-drawing chars from light to heavy, add (1 << n) - 1 to each.
 
         // n = 1
         private static final char HORIZONTAL = '\u2500';

--- a/bishopsGambit/src/main/java/game/InvalidPromotionException.java
+++ b/bishopsGambit/src/main/java/game/InvalidPromotionException.java
@@ -8,9 +8,4 @@ public class InvalidPromotionException extends IllegalArgumentException
     {
         super( "Cannot promote to a piece of type '" + type + "'." );
     }
-
-    public InvalidPromotionException( String code )
-    {
-        super( "Unrecognised promotion piece type code '" + code + "'." );
-    }
 }

--- a/bishopsGambit/src/main/java/gui/PieceComp.java
+++ b/bishopsGambit/src/main/java/gui/PieceComp.java
@@ -1,8 +1,5 @@
 package main.java.gui;
 
-import java.awt.Image;
-
-import javax.swing.ImageIcon;
 import javax.swing.JLabel;
 
 import main.java.Orderable;
@@ -26,10 +23,7 @@ public class PieceComp extends JLabel implements Orderable
     public void setScale( int scale )
     {
         setSize( scale, scale );
-
-        Image imageFull = Images.getImage( getPiece() );
-        Image imageScaled = imageFull.getScaledInstance( scale, scale, Image.SCALE_SMOOTH );
-        setIcon( new ImageIcon( imageScaled ) );
+        setIcon( Images.createIcon( piece.getColour(), piece.getType(), scale ) );
     }
 
     @Override
@@ -44,6 +38,6 @@ public class PieceComp extends JLabel implements Orderable
     @Override
     public int ordinal()
     {
-        return getPiece().getType().ordinal();
+        return piece.getType().ordinal();
     }
 }

--- a/bishopsGambit/src/main/java/gui/SquareComp.java
+++ b/bishopsGambit/src/main/java/gui/SquareComp.java
@@ -135,6 +135,11 @@ public class SquareComp extends JLayeredPane
         return null;
     }
 
+    /**
+     * Sets the border of this button to an empty border.
+     * 
+     * @return {@code null}
+     */
     public SquareComp resetBorder()
     {
         setBorder( BorderFactory.createEmptyBorder() );
@@ -164,7 +169,7 @@ public class SquareComp extends JLayeredPane
 
     public int getIndex()
     {
-        return Square.getIndex( getFile(), getRank() );
+        return Square.getIndex( file, rank );
     }
 
     private class CircleComp extends JComponent

--- a/bishopsGambit/src/main/java/io/Images.java
+++ b/bishopsGambit/src/main/java/io/Images.java
@@ -7,9 +7,7 @@ import javax.imageio.ImageIO;
 import javax.swing.Icon;
 import javax.swing.ImageIcon;
 
-import main.java.pieces.Piece;
 import main.java.pieces.Piece.Typ;
-import main.java.player.Player;
 import main.java.player.Player.Colour;
 
 public class Images
@@ -45,11 +43,6 @@ public class Images
         return image;
     }
 
-    public static Image getImage( Piece piece )
-    {
-        return getImage( piece.getColour(), piece.getType() );
-    }
-
     public static Image getImage( Colour colour, Typ type )
     {
         return switch ( colour )
@@ -76,8 +69,41 @@ public class Images
         };
     }
 
-    public static Icon getIcon( Player player, Typ type )
+    /**
+     * Creates an {@code ImageIcon} of the piece with the given <b>colour</b> and <b>type</b>. The
+     * width and height of the instance returned are equal to that of the original image.
+     * 
+     * @param colour the piece colour (i.e. the colour of the player the piece belongs to)
+     * @param type   the piece type
+     * @return an {@code ImageIcon} of the piece with the given <b>colour</b> and <b>type</b>
+     */
+    public static Icon createIcon( Colour colour, Typ type )
     {
-        return new ImageIcon( getImage( player.getColour(), type ) );
+        return createIcon( colour, type, -1 );
+    }
+
+    /**
+     * Creates an {@code ImageIcon} of the piece with the given <b>colour</b> and <b>type</b>. If
+     * positive, the width and height of the instance returned are equal to the given <b>scale</b>.
+     * If negative, the original image dimensions are used. If zero, an
+     * {@code IllegalArgumentException} is thrown.
+     * 
+     * @param colour the piece colour (i.e. the colour of the player the piece belongs to)
+     * @param type   the piece type
+     * @param scale  the width and height of the icon
+     * @return a scaled {@code ImageIcon} of the piece with the given <b>colour</b> and <b>type</b>
+     * @throws IllegalArgumentException if <b>scale</b> is zero
+     */
+    public static Icon createIcon( Colour colour, Typ type, int scale )
+    {
+        if ( scale == 0 )
+            throw new IllegalArgumentException( "Scale must be non-zero." );
+
+        Image image = getImage( colour, type );
+
+        if ( scale > 0 )
+            image = image.getScaledInstance( scale, scale, Image.SCALE_SMOOTH );
+
+        return new ImageIcon( image );
     }
 }

--- a/bishopsGambit/src/main/java/pieces/Piece.java
+++ b/bishopsGambit/src/main/java/pieces/Piece.java
@@ -155,6 +155,12 @@ public abstract class Piece
         return Math.abs( fileDiff ) == 2 && rankDiff == 0;
     }
 
+    /**
+     * Returns a boolean indicating whether this piece is one of the given <b>types</b>.
+     * 
+     * @param types the piece types to check
+     * @return {@code true} if this piece is one of the given types; {@code false} otherwise
+     */
     public boolean isType( Typ... types )
     {
         return Arrays.asList( types ).contains( getType() );

--- a/bishopsGambit/src/main/java/player/Player.java
+++ b/bishopsGambit/src/main/java/player/Player.java
@@ -192,5 +192,16 @@ public class Player
         {
             return this.str;
         }
+
+        public Colour transpose()
+        {
+            if ( this == WHITE )
+                return BLACK;
+
+            if ( this == BLACK )
+                return WHITE;
+
+            return null;
+        }
     }
 }


### PR DESCRIPTION
Implemented functionality for the **Previous Move** and **Next Move** buttons.

When the **Previous Move** button is pressed, the board state prior to the one currently displayed is shown.
When the **Next Move** button is pressed, the board state after the one currently displayed is shown.

If a previous board state is being displayed, the 'from' and 'to' squares are deselected and the user is unable to interact with any squares until returning to the latest board state.

In the example below, the square containing the White King is selected, then the **Previous Move** button is clicked, followed by the **Next Move** button.

<img width=33% alt="Initial board state" src="https://github.com/user-attachments/assets/e1d67942-7baf-4f40-ac0c-42c6d87d2c5e" />
<img width=33% alt="'Previous Move' button clicked" src="https://github.com/user-attachments/assets/0254f12f-b54d-4a62-af75-63003f86e637" />
<img width=33% alt="'Next Move' button clicked" src="https://github.com/user-attachments/assets/1fdf395a-9f22-4e48-8ead-e8ec249b9320" />