### PR TITLE
BG-20 - Fix pawn control when validating castling

### DIFF
--- a/config/eclipse/dictionary.txt
+++ b/config/eclipse/dictionary.txt
@@ -1,13 +1,16 @@
 accessors
+checkmate
 checkmated
 chessboard
 color
 deselect
 en
+endpoints
 kingside
 passant
 queenside
 sortable
+stalemate
 stalemated
 tabletop
 vgap

--- a/src/main/java/io/github/ollybishop/bishopsgambit/board/Board.java
+++ b/src/main/java/io/github/ollybishop/bishopsgambit/board/Board.java
@@ -3,7 +3,9 @@ package io.github.ollybishop.bishopsgambit.board;
 import java.util.ArrayList;
 import java.util.List;
 
+import io.github.ollybishop.bishopsgambit.pieces.Bishop;
 import io.github.ollybishop.bishopsgambit.pieces.King;
+import io.github.ollybishop.bishopsgambit.pieces.Knight;
 import io.github.ollybishop.bishopsgambit.pieces.Pawn;
 import io.github.ollybishop.bishopsgambit.pieces.Piece;
 import io.github.ollybishop.bishopsgambit.pieces.Rook;
@@ -86,20 +88,7 @@ public class Board extends ArrayList<Square>
      */
     public boolean containsPiece( Piece piece )
     {
-        return stream().anyMatch( sq -> sq.getPiece() == piece );
-    }
-
-    /**
-     * Finds and returns the square whose coordinates match the given string. For example, an input
-     * of "a1" would return the square with file 'a' and rank '1'.
-     * 
-     * @param coords the coordinates of the desired square as a string
-     * @return the square whose coordinates match the given string (if it exists); {@code null}
-     *         otherwise
-     */
-    public Square getSquare( String coords )
-    {
-        return getSquare( coords.charAt( 0 ), coords.charAt( 1 ) );
+        return stream().anyMatch( square -> square.getPiece() == piece );
     }
 
     /**
@@ -117,12 +106,14 @@ public class Board extends ArrayList<Square>
         return null;
     }
 
-    public static boolean isValidSquare( String coords )
+    public Square getSquare( Square origin, int dx, int dy )
     {
-        return isValidSquare( coords.charAt( 0 ), coords.charAt( 1 ) );
+        char file = (char) ( origin.getFile() + dx );
+        char rank = (char) ( origin.getRank() + dy );
+        return getSquare( file, rank );
     }
 
-    private static boolean isValidSquare( char file, char rank )
+    public static boolean isValidSquare( char file, char rank )
     {
         return 'a' <= file && file <= 'h' && '1' <= rank && rank <= '8';
     }
@@ -152,20 +143,20 @@ public class Board extends ArrayList<Square>
 
         Piece piece = from.getPiece();
 
-        int x = Integer.signum( to.fileDiff( from ) );
-        Square s1 = from.travel( this, x, 0 );
+        int dx = Integer.signum( to.fileDiff( from ) );
+        Square adjacent = getSquare( from, dx, 0 );
 
-        if ( piece instanceof Pawn && piece.movedOneSquareDiagonallyForward( from, to ) && !to.isOccupied() )
+        // En passant
+        if ( piece instanceof Pawn && piece.movedOneSquareDiagonallyForward( from, to ) && to.isEmpty() )
         {
-            // En passant
-            replace( s1, s1.clone() );
+            replace( adjacent, adjacent.clone() );
         }
+        // Castling
         else if ( piece instanceof King && piece.movedTwoSquaresHorizontally( from, to ) )
         {
-            // Castling
-            Rook rook = piece.getPlayer().getRook( x );
-            Square r = rook.getSquare( this );
-            movePiece( r, s1 );
+            Rook rook = piece.getPlayer().getRook( dx );
+            Square rookSquare = rook.getSquare( this );
+            movePiece( rookSquare, adjacent );
         }
 
         if ( piece instanceof Rook || piece instanceof King )
@@ -209,15 +200,15 @@ public class Board extends ArrayList<Square>
         add( index, s2 );
     }
 
-    public Piece promote( Pawn pawn, Piece.Type promType )
+    public Piece promote( Pawn pawn, Piece.Type newType )
     {
         Square square = pawn.getSquare( this );
-        Piece promPiece = Piece.newInstance( promType,
-                                             pawn.getPlayer(),
-                                             square.getFile(),
-                                             square.getRank() );
-        square.setPiece( promPiece );
-        return promPiece;
+        Piece newPiece = Piece.newInstance( newType,
+                                            pawn.getPlayer(),
+                                            square.getFile(),
+                                            square.getRank() );
+        square.setPiece( newPiece );
+        return newPiece;
     }
 
     private void revokeCastlingRights( Piece piece )
@@ -250,6 +241,24 @@ public class Board extends ArrayList<Square>
         }
     }
 
+    public boolean isCastlingAllowed( Rook rook )
+    {
+        return switch ( rook.getColour() )
+        {
+            case WHITE -> switch ( rook.getBoardSide() )
+            {
+                case QUEENSIDE -> whiteQueensideCastlingAllowed;
+                case KINGSIDE -> whiteKingsideCastlingAllowed;
+            };
+
+            case BLACK -> switch ( rook.getBoardSide() )
+            {
+                case QUEENSIDE -> blackQueensideCastlingAllowed;
+                case KINGSIDE -> blackKingsideCastlingAllowed;
+            };
+        };
+    }
+
     private void updateEnPassantPawn( Square from, Square to )
     {
         Piece piece = from.getPiece();
@@ -266,33 +275,55 @@ public class Board extends ArrayList<Square>
         return from.getPiece().getLegalMoves( this ).contains( to );
     }
 
+    public boolean moveWouldLeavePlayerInCheck( Player player, Square from, Square to )
+    {
+        return player.isInCheck( cloneAndMove( from, to ) );
+    }
+
     public int getMaterialDifference()
     {
         return getPieces().stream()
-                          .mapToInt( pc -> pc.getSign() * pc.getValue() )
+                          .mapToInt( piece -> piece.getPlayerCoefficient() * piece.getValue() )
                           .sum();
     }
 
     public boolean hasInsufficientMaterial()
     {
-        // All pieces currently on the board (excluding the Kings)
-        List<Piece> pieces = getPieces().stream().filter( pc -> !pc.isType( Piece.Type.KING ) ).toList();
+        // Get all non-king pieces currently on the board
+        List<Piece> pieces = getPieces().stream()
+                                        .filter( piece -> !( piece instanceof King ) )
+                                        .toList();
 
-        return switch ( pieces.size() )
+        switch ( pieces.size() )
         {
-            // King versus King
-            case 0 -> true;
+            // King versus king
+            case 0:
+                return true;
 
-            // King and Bishop versus King, King and Knight versus King
-            case 1 -> pieces.stream().allMatch( pc -> pc.isType( Piece.Type.BISHOP, Piece.Type.KNIGHT ) );
+            // King and knight/bishop versus king
+            case 1:
+                return pieces.get( 0 ) instanceof Knight ||
+                       pieces.get( 0 ) instanceof Bishop;
 
-            // King and Bishop versus King and Bishop with the Bishops on the same colour
-            case 2 -> pieces.stream().allMatch( pc -> pc.isType( Piece.Type.BISHOP ) ) &&
-                      pieces.stream().map( Piece::getPlayer ).distinct().count() > 1 &&
-                      pieces.stream().map( pc -> pc.getSquare( this ).getParity() ).distinct().count() == 1;
+            // King and bishop versus king and bishop with the bishops on the same colour
+            case 2:
+                if ( pieces.get( 0 ) instanceof Bishop &&
+                     pieces.get( 1 ) instanceof Bishop )
+                {
+                    Bishop first = (Bishop) pieces.get( 0 );
+                    Bishop second = (Bishop) pieces.get( 1 );
 
-            default -> false;
-        };
+                    boolean differentPlayers = first.getColour() != second.getColour();
+                    boolean sameSquareShade = first.getSquareShade() == second.getSquareShade();
+
+                    return differentPlayers && sameSquareShade;
+                }
+
+                return false;
+
+            default:
+                return false;
+        }
     }
 
     public void print()
@@ -300,10 +331,20 @@ public class Board extends ArrayList<Square>
         Printer.print( this );
     }
 
+    public static enum Side
+    {
+        QUEENSIDE, KINGSIDE
+    }
+
     private static class Printer
     {
-        // For each box-drawing char below, n is the number of "prongs" that char has.
-        // To convert box-drawing chars from light to heavy, add (1 << n) - 1 to each.
+        /*
+         * For each box-drawing character below, n is the number of line segments obtained by splitting
+         * the character at its endpoints and junctions.
+         * 
+         * To convert a light box-drawing character to its heavy equivalent, add (1 << n) - 1, i.e. one
+         * less than two to the power of n.
+         */
 
         // n = 1
         private static final char HORIZONTAL = '\u2500';
@@ -336,8 +377,9 @@ public class Board extends ArrayList<Square>
 
             for ( char file = 'a'; file <= 'h'; file++ )
             {
-                for ( int j = 0; j < 3; j++ )
-                    row.append( HORIZONTAL );
+                row.append( HORIZONTAL )
+                   .append( HORIZONTAL )
+                   .append( HORIZONTAL );
 
                 if ( file < 'h' )
                     row.append( horizontal );

--- a/src/main/java/io/github/ollybishop/bishopsgambit/board/Square.java
+++ b/src/main/java/io/github/ollybishop/bishopsgambit/board/Square.java
@@ -55,52 +55,64 @@ public class Square
     }
 
     /**
+     * Returns whether this square is empty.
+     * 
+     * @return {@code true} if this square is empty; {@code false} otherwise
+     */
+    public boolean isEmpty()
+    {
+        return getPiece() == null;
+    }
+
+    /**
      * Returns whether this square is occupied by a piece.
      * 
      * @return {@code true} if this square is occupied by a piece; {@code false} otherwise
      */
     public boolean isOccupied()
     {
-        return getPiece() != null;
+        return !isEmpty();
     }
 
     /**
-     * Returns whether this square is occupied by one of the given player's pieces.
+     * Returns whether this square is occupied by a piece belonging to the given player.
      * 
      * @param player the player to check
-     * @return {@code true} if this square is occupied by one of the given player's pieces;
+     * @return {@code true} if this square is occupied by a piece belonging to the given player;
      *         {@code false} otherwise
      */
     public boolean isOccupiedBy( Player player )
     {
-        return player.getPieces().contains( getPiece() );
+        return isOccupied() && getPiece().getPlayer() == player;
     }
 
     /**
-     * Returns whether this square is occupied by an opposing piece.
+     * Returns whether this square is occupied by a piece belonging to the given player's opponent.
      * 
-     * @param player the player whose opponent is checked
-     * @return {@code true} if this square is occupied by an opposing piece; {@code false} otherwise
+     * @param player the player to check against
+     * @return {@code true} if this square is occupied by a piece belonging to the given player's
+     *         opponent; {@code false} otherwise
      */
     public boolean isOccupiedByOpponentOf( Player player )
     {
-        return isOccupied() && !isOccupiedBy( player );
+        return isOccupied() && getPiece().getPlayer() != player;
     }
 
     /**
-     * Returns whether this square is a pseudo-legal move destination for any opposing piece.
+     * Returns whether this square is controlled by a piece belonging to the given player's
+     * opponent.
      * 
-     * @param player the player whose opponent's pieces are considered
+     * @param player the player whose opponent's pieces are checked
      * @param board  the chessboard
-     * @return {@code true} if this square is pseudo-legally reachable by any opposing piece;
-     *         {@code false} otherwise
+     * @return {@code true} if this square is controlled by a piece belonging to the given player's
+     *         opponent; {@code false} otherwise
      */
-    public boolean isPseudoLegallyReachableByOpponentOf( Player player, Board board )
+    public boolean isControlledByOpponentOf( Player player, Board board )
     {
         return board.getPieces()
                     .stream()
                     .filter( piece -> piece.getPlayer() != player )
-                    .anyMatch( piece -> piece.canPseudoLegallyMoveTo( this, board ) );
+                    .anyMatch( piece -> piece.controls( this, board ) );
     }
 
     public boolean isOnLastRank( Player player )
@@ -110,11 +122,6 @@ public class Square
             case WHITE -> getRank() == '8';
             case BLACK -> getRank() == '1';
         };
-    }
-
-    public Square travel( Board board, int x, int y )
-    {
-        return board.getSquare( (char) ( getFile() + x ), (char) ( getRank() + y ) );
     }
 
     public int fileDiff( Square square )
@@ -127,14 +134,9 @@ public class Square
         return getRank() - square.getRank();
     }
 
-    public int getParity()
+    public static Shade getShade( char file, char rank )
     {
-        return getParity( getFile(), getRank() );
-    }
-
-    public static int getParity( char file, char rank )
-    {
-        return ( file + rank ) % 2;
+        return ( file + rank ) % 2 == 0 ? Shade.DARK : Shade.LIGHT;
     }
 
     public int getIndex()
@@ -145,5 +147,10 @@ public class Square
     public static int getIndex( char file, char rank )
     {
         return 8 * ( file - 'a' ) + rank - '1';
+    }
+
+    public enum Shade
+    {
+        DARK, LIGHT
     }
 }

--- a/src/main/java/io/github/ollybishop/bishopsgambit/game/Game.java
+++ b/src/main/java/io/github/ollybishop/bishopsgambit/game/Game.java
@@ -1,7 +1,6 @@
 package io.github.ollybishop.bishopsgambit.game;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
 
 import io.github.ollybishop.bishopsgambit.board.Board;
@@ -130,57 +129,52 @@ public class Game
         return getNumberOfPliesPlayed() % 2 == 0 ? white : black;
     }
 
-    private String[] parseUci( String uci )
-    {
-        if ( uci == null )
-            throw new IllegalArgumentException( "String cannot be null." );
-
-        if ( uci.length() < 4 || uci.length() > 5 )
-            throw new IllegalArgumentException( "String must be 4 or 5 characters in length." );
-
-        String value1 = uci.substring( 0, 2 );
-        String value2 = uci.substring( 2, 4 );
-        String value3 = uci.substring( 4 );
-
-        if ( !Board.isValidSquare( value1 ) )
-            throw new IllegalArgumentException( "First pair of characters '" + value1 + "' must represent a valid square." );
-
-        if ( !Board.isValidSquare( value2 ) )
-            throw new IllegalArgumentException( "Second pair of characters '" + value2 + "' must represent a valid square." );
-
-        if ( !Arrays.asList( "", "n", "b", "r", "q" ).contains( value3 ) )
-            throw new IllegalArgumentException( "Fifth character '" + value3 + "' must be empty or represent a valid piece." );
-
-        return new String[] { value1, value2, value3 };
-    }
-
     /**
      * @param uci a string representing the move in Universal Chess Interface (UCI) notation
      * @return the new piece (if promoting); {@code null} otherwise
      */
     public Piece makeMove( String uci )
     {
-        String[] values = parseUci( uci );
+        Object[] moveInfo = getMoveInfo( uci, getActiveBoard() );
 
-        Board board = getActiveBoard();
+        Square from = (Square) moveInfo[ 0 ];
+        Square to = (Square) moveInfo[ 1 ];
+        Piece.Type newType = (Piece.Type) moveInfo[ 2 ];
 
-        Square from = board.getSquare( values[ 0 ] );
-        Square to = board.getSquare( values[ 1 ] );
-
-        return switch ( values[ 2 ] )
-        {
-            case "n" -> makeMove( from, to, Piece.Type.KNIGHT );
-            case "b" -> makeMove( from, to, Piece.Type.BISHOP );
-            case "r" -> makeMove( from, to, Piece.Type.ROOK );
-            case "q" -> makeMove( from, to, Piece.Type.QUEEN );
-
-            default -> makeMove( from, to );
-        };
+        return makeMove( from, to, newType );
     }
 
-    public Piece makeMove( Square from, Square to )
+    private Object[] getMoveInfo( String uci, Board board )
     {
-        return makeMove( from, to, null );
+        if ( uci == null )
+            throw new IllegalArgumentException( "UCI string cannot be null." );
+
+        if ( uci.length() < 4 || uci.length() > 5 )
+            throw new IllegalArgumentException( "UCI string must be 4 or 5 characters in length." );
+
+        if ( !Board.isValidSquare( uci.charAt( 0 ), uci.charAt( 1 ) ) )
+            throw new IllegalArgumentException( "First & second characters in UCI string must represent a valid square." );
+
+        if ( !Board.isValidSquare( uci.charAt( 2 ), uci.charAt( 3 ) ) )
+            throw new IllegalArgumentException( "Third & fourth characters in UCI string must represent a valid square." );
+
+        Square from = board.getSquare( uci.charAt( 0 ), uci.charAt( 1 ) );
+        Square to = board.getSquare( uci.charAt( 2 ), uci.charAt( 3 ) );
+
+        if ( uci.length() == 4 )
+            return new Object[] { from, to, null };
+
+        Piece.Type newType = switch ( uci.charAt( 4 ) )
+        {
+            case 'n' -> Piece.Type.KNIGHT;
+            case 'b' -> Piece.Type.BISHOP;
+            case 'r' -> Piece.Type.ROOK;
+            case 'q' -> Piece.Type.QUEEN;
+
+            default -> throw new IllegalArgumentException( "Fifth character in UCI string must represent a valid piece." );
+        };
+
+        return new Object[] { from, to, newType };
     }
 
     /**

--- a/src/main/java/io/github/ollybishop/bishopsgambit/gui/ApplicationFrame.java
+++ b/src/main/java/io/github/ollybishop/bishopsgambit/gui/ApplicationFrame.java
@@ -642,7 +642,7 @@ public class ApplicationFrame extends JFrame
         }
         else
         {
-            game.makeMove( from, to );
+            game.makeMove( from, to, null );
         }
 
         boardIndex = getLatestBoardIndex();

--- a/src/main/java/io/github/ollybishop/bishopsgambit/gui/SquareComponent.java
+++ b/src/main/java/io/github/ollybishop/bishopsgambit/gui/SquareComponent.java
@@ -19,9 +19,10 @@ import io.github.ollybishop.bishopsgambit.util.ComponentUtils;
 
 public class SquareComponent extends JLayeredPane
 {
-    private static final Color DARK = new Color( 209, 139, 71 );
-    private static final Color LIGHT = new Color( 254, 206, 157 );
-    private static final Color HIGHLIGHT = ColorUtils.blend( Color.YELLOW, Color.WHITE );
+    private static final Color DARK_SQUARE_BG = new Color( 209, 139, 71 );
+    private static final Color LIGHT_SQUARE_BG = new Color( 254, 206, 157 );
+
+    private static final Color YELLOW_WHITE = ColorUtils.blend( Color.YELLOW, Color.WHITE );
 
     private static final Font ROBOTO_MEDIUM = Fonts.importFont( "Roboto", Weight.MEDIUM );
 
@@ -58,8 +59,10 @@ public class SquareComponent extends JLayeredPane
         this.file = file;
         this.rank = rank;
 
-        this.defaultBackground = Square.getParity( file, rank ) == 0 ? DARK : LIGHT;
-        this.defaultForeground = Square.getParity( file, rank ) == 0 ? LIGHT : DARK;
+        Square.Shade squareShade = Square.getShade( file, rank );
+
+        this.defaultBackground = squareShade == Square.Shade.DARK ? DARK_SQUARE_BG : LIGHT_SQUARE_BG;
+        this.defaultForeground = squareShade == Square.Shade.DARK ? LIGHT_SQUARE_BG : DARK_SQUARE_BG;
 
         this.fileLabel = new JLabel( String.valueOf( file ) );
         fileLabel.setVerticalAlignment( SwingConstants.BOTTOM );
@@ -123,7 +126,7 @@ public class SquareComponent extends JLayeredPane
      */
     protected void select()
     {
-        setBackground( ColorUtils.blend( defaultBackground, HIGHLIGHT, 1, 3 ) );
+        setBackground( ColorUtils.blend( defaultBackground, YELLOW_WHITE, 1, 3 ) );
     }
 
     /**

--- a/src/main/java/io/github/ollybishop/bishopsgambit/pieces/Bishop.java
+++ b/src/main/java/io/github/ollybishop/bishopsgambit/pieces/Bishop.java
@@ -9,9 +9,18 @@ import io.github.ollybishop.bishopsgambit.player.Player;
 
 public class Bishop extends Piece
 {
+    private final Square.Shade squareShade;
+
     public Bishop( Player player, char startFile, char startRank )
     {
         super( player, startFile, startRank );
+
+        squareShade = Square.getShade( startFile, startRank );
+    }
+
+    public Square.Shade getSquareShade()
+    {
+        return this.squareShade;
     }
 
     @Override
@@ -27,41 +36,41 @@ public class Bishop extends Piece
     }
 
     @Override
-    public List<Square> getPseudoLegalMoves( Board board )
+    protected List<Square> getCandidateSquares( Board board, boolean includeFriendlySquares )
     {
-        return getPseudoLegalMoves( board, this );
+        return getCandidateSquares( this, board, includeFriendlySquares );
     }
 
-    public static List<Square> getPseudoLegalMoves( Board board, Piece piece )
+    protected static List<Square> getCandidateSquares( Piece piece, Board board, boolean includeFriendlySquares )
     {
-        List<Square> moves = new ArrayList<>();
+        List<Square> candidateSquares = new ArrayList<>();
 
         Square square = piece.getSquare( board );
 
-        for ( int x : new int[] { -1, 1 } )
+        for ( int dx : new int[] { -1, 1 } )
         {
-            for ( int y : new int[] { -1, 1 } )
+            for ( int dy : new int[] { -1, 1 } )
             {
                 for ( int n = 1; n < 8; n++ )
                 {
-                    Square s = square.travel( board, n * x, n * y );
+                    Square s = board.getSquare( square, n * dx, n * dy );
 
                     if ( s == null )
                         break;
 
                     if ( s.isOccupied() )
                     {
-                        if ( s.isOccupiedByOpponentOf( piece.getPlayer() ) )
-                            moves.add( s );
+                        if ( includeFriendlySquares || s.isOccupiedByOpponentOf( piece.getPlayer() ) )
+                            candidateSquares.add( s );
 
                         break;
                     }
 
-                    moves.add( s );
+                    candidateSquares.add( s );
                 }
             }
         }
 
-        return moves;
+        return candidateSquares;
     }
 }

--- a/src/main/java/io/github/ollybishop/bishopsgambit/pieces/King.java
+++ b/src/main/java/io/github/ollybishop/bishopsgambit/pieces/King.java
@@ -27,82 +27,67 @@ public class King extends Piece
     }
 
     @Override
-    public List<Square> getPseudoLegalMoves( Board board )
+    public List<Square> getCandidateSquares( Board board, boolean includeFriendlySquares )
     {
-        List<Square> moves = new ArrayList<>();
+        List<Square> candidateSquares = new ArrayList<>();
 
         Square square = getSquare( board );
 
-        for ( int x : new int[] { -1, 0, 1 } )
+        for ( int dx : new int[] { -1, 0, 1 } )
         {
-            for ( int y : new int[] { -1, 0, 1 } )
+            for ( int dy : new int[] { -1, 0, 1 } )
             {
-                Square s = square.travel( board, x, y );
+                if ( dx == 0 && dy == 0 )
+                    continue;
 
-                if ( s != null && !s.isOccupiedBy( getPlayer() ) )
-                    moves.add( s );
+                Square s = board.getSquare( square, dx, dy );
+
+                if ( s == null )
+                    continue;
+
+                if ( includeFriendlySquares || s.isEmpty() || s.isOccupiedByOpponentOf( getPlayer() ) )
+                    candidateSquares.add( s );
             }
         }
 
-        return moves;
+        return candidateSquares;
     }
 
     @Override
     public List<Square> getLegalMoves( Board board )
     {
-        List<Square> moves = new ArrayList<>( super.getLegalMoves( board ) );
+        if ( isUnderAttack( board ) )
+            return super.getLegalMoves( board );
 
-        if ( !isUnderAttack( board ) )
+        List<Square> legalMoves = new ArrayList<>( super.getLegalMoves( board ) );
+
+        for ( int dx : new int[] { -1, 1 } )
         {
-            for ( int x : new int[] { -1, 1 } )
+            Rook rook = getPlayer().getRook( dx );
+
+            if ( board.isCastlingAllowed( rook ) )
             {
-                Rook rook = getPlayer().getRook( x );
+                Square kingSquare = getSquare( board );
+                Square rookSquare = rook.getSquare( board );
 
-                if ( isCastlingAllowed( rook, board ) )
-                {
-                    Square k = getSquare( board );
-                    Square r = rook.getSquare( board );
+                // One square adjacent to king (rook moves here)
+                Square kingAdjacent = board.getSquare( kingSquare, dx, 0 );
 
-                    Square k1 = k.travel( board, x, 0 ); // One square adjacent to king (rook moves here)
-                    Square k2 = k.travel( board, 2 * x, 0 ); // Two squares adjacent to king (king moves here)
-                    Square r1 = r.travel( board, -x, 0 ); // One square adjacent to rook (same as 'k2' when castling kingside)
+                // Two squares adjacent to king (king moves here)
+                Square kingDestination = board.getSquare( kingSquare, 2 * dx, 0 );
 
-                    if ( !k1.isOccupied() &&
-                         !k2.isOccupied() &&
-                         !r1.isOccupied() &&
-                         !k1.isPseudoLegallyReachableByOpponentOf( getPlayer(), board ) &&
-                         !k2.isPseudoLegallyReachableByOpponentOf( getPlayer(), board ) )
-                        moves.add( k2 );
-                }
+                // One square adjacent to rook (same as 'k2' when castling kingside)
+                Square rookAdjacent = board.getSquare( rookSquare, -dx, 0 );
+
+                if ( kingAdjacent.isEmpty() &&
+                     kingDestination.isEmpty() &&
+                     rookAdjacent.isEmpty() &&
+                     !kingAdjacent.isControlledByOpponentOf( getPlayer(), board ) &&
+                     !kingDestination.isControlledByOpponentOf( getPlayer(), board ) )
+                    legalMoves.add( kingDestination );
             }
         }
 
-        return moves;
-    }
-
-    private boolean isCastlingAllowed( Rook rook, Board board )
-    {
-        switch ( getColour() )
-        {
-            case WHITE:
-                if ( rook == getPlayer().getQueensideRook() )
-                    return board.isWhiteQueensideCastlingAllowed();
-
-                if ( rook == getPlayer().getKingsideRook() )
-                    return board.isWhiteKingsideCastlingAllowed();
-
-                break;
-
-            case BLACK:
-                if ( rook == getPlayer().getQueensideRook() )
-                    return board.isBlackQueensideCastlingAllowed();
-
-                if ( rook == getPlayer().getKingsideRook() )
-                    return board.isBlackKingsideCastlingAllowed();
-
-                break;
-        }
-
-        throw new RuntimeException();
+        return legalMoves;
     }
 }

--- a/src/main/java/io/github/ollybishop/bishopsgambit/pieces/Knight.java
+++ b/src/main/java/io/github/ollybishop/bishopsgambit/pieces/Knight.java
@@ -27,26 +27,29 @@ public class Knight extends Piece
     }
 
     @Override
-    public List<Square> getPseudoLegalMoves( Board board )
+    protected List<Square> getCandidateSquares( Board board, boolean includeFriendlySquares )
     {
-        List<Square> moves = new ArrayList<>();
+        List<Square> candidateSquares = new ArrayList<>();
 
         Square square = getSquare( board );
 
-        for ( int x : new int[] { -1, 1 } )
+        for ( int dx : new int[] { -1, 1 } )
         {
-            for ( int y : new int[] { -1, 1 } )
+            for ( int dy : new int[] { -1, 1 } )
             {
                 for ( int n : new int[] { 1, 2 } )
                 {
-                    Square s = square.travel( board, n * x, ( 3 - n ) * y );
+                    Square s = board.getSquare( square, n * dx, ( 3 - n ) * dy );
 
-                    if ( s != null && !s.isOccupiedBy( getPlayer() ) )
-                        moves.add( s );
+                    if ( s == null )
+                        continue;
+
+                    if ( includeFriendlySquares || s.isEmpty() || s.isOccupiedByOpponentOf( getPlayer() ) )
+                        candidateSquares.add( s );
                 }
             }
         }
 
-        return moves;
+        return candidateSquares;
     }
 }

--- a/src/main/java/io/github/ollybishop/bishopsgambit/pieces/Pawn.java
+++ b/src/main/java/io/github/ollybishop/bishopsgambit/pieces/Pawn.java
@@ -6,6 +6,7 @@ import java.util.List;
 import io.github.ollybishop.bishopsgambit.board.Board;
 import io.github.ollybishop.bishopsgambit.board.Square;
 import io.github.ollybishop.bishopsgambit.player.Player;
+import io.github.ollybishop.bishopsgambit.util.ListUtils;
 
 public class Pawn extends Piece
 {
@@ -27,47 +28,76 @@ public class Pawn extends Piece
     }
 
     @Override
-    public List<Square> getPseudoLegalMoves( Board board )
+    protected List<Square> getCandidateSquares( Board board, boolean includeFriendlySquares )
     {
-        List<Square> moves = new ArrayList<>();
+        List<Square> forwardMoveSquares = new ArrayList<>();
 
         Square square = getSquare( board );
-        int y = getSign();
+        int dy = getPlayerCoefficient();
 
-        // Move forward one or two squares
-        for ( int n : new int[] { 1, 2 } )
+        Square oneRankForward = board.getSquare( square, 0, dy );
+
+        if ( oneRankForward.isEmpty() )
         {
-            if ( n == 1 || square == getStartSquare( board ) )
-            {
-                Square s = square.travel( board, 0, n * y );
+            forwardMoveSquares.add( oneRankForward );
 
-                if ( s != null )
-                {
-                    if ( s.isOccupied() )
-                        break;
+            Square twoRanksForward = board.getSquare( square, 0, 2 * dy );
 
-                    moves.add( s );
-                }
-            }
+            if ( square == getStartSquare( board ) && twoRanksForward.isEmpty() )
+                forwardMoveSquares.add( twoRanksForward );
         }
 
-        // Capture diagonally
-        for ( int x : new int[] { -1, 1 } )
+        // Only include controlled squares that would result in a capture
+        List<Square> captureSquares = getControlledSquares( board ).stream()
+                                                                   .filter( s -> canCaptureOn( s, board ) )
+                                                                   .toList();
+
+        return ListUtils.combine( forwardMoveSquares, captureSquares );
+    }
+
+    /**
+     * Returns whether this pawn can capture on the given square.
+     * <p>
+     * A pawn can capture on the given square if it is occupied by an opposing piece, or if moving
+     * there would capture the board's en passant pawn. This method does not check whether making
+     * the move would leave the moving player in check.
+     * 
+     * @param square the destination square
+     * @param board  the chessboard
+     * @return {@code true} if this pawn can capture on the given square; {@code false} otherwise
+     */
+    private boolean canCaptureOn( Square square, Board board )
+    {
+        if ( square.isOccupiedByOpponentOf( getPlayer() ) )
+            return true;
+
+        Pawn enPassantPawn = board.getEnPassantPawn();
+
+        if ( enPassantPawn == null )
+            return false;
+
+        char file = square.getFile();
+        char rank = getSquare( board ).getRank();
+
+        return board.getSquare( file, rank ).getPiece() == enPassantPawn;
+    }
+
+    @Override
+    public List<Square> getControlledSquares( Board board )
+    {
+        List<Square> controlledSquares = new ArrayList<>();
+
+        Square square = getSquare( board );
+        int dy = getPlayerCoefficient();
+
+        for ( int dx : new int[] { -1, 1 } )
         {
-            Square s0 = square.travel( board, x, 0 );
-            Square s1 = square.travel( board, x, y );
+            Square diagonal = board.getSquare( square, dx, dy );
 
-            boolean regularCapture = s1 != null &&
-                                     s1.isOccupiedByOpponentOf( getPlayer() );
-
-            boolean enPassantCapture = s0 != null &&
-                                       s0.isOccupiedByOpponentOf( getPlayer() ) &&
-                                       s0.getPiece() == board.getEnPassantPawn();
-
-            if ( regularCapture || enPassantCapture )
-                moves.add( s1 );
+            if ( diagonal != null )
+                controlledSquares.add( diagonal );
         }
 
-        return moves;
+        return controlledSquares;
     }
 }

--- a/src/main/java/io/github/ollybishop/bishopsgambit/pieces/Piece.java
+++ b/src/main/java/io/github/ollybishop/bishopsgambit/pieces/Piece.java
@@ -36,7 +36,7 @@ public abstract class Piece
 
     public Player getPlayer()
     {
-        return this.player;
+        return player;
     }
 
     public Player.Colour getColour()
@@ -44,13 +44,24 @@ public abstract class Piece
         return getPlayer().getColour();
     }
 
-    public int getSign()
+    public int getPlayerCoefficient()
     {
-        return getPlayer().getSign();
+        return getPlayer().getCoefficient();
+    }
+
+    public Board.Side getBoardSide()
+    {
+        if ( startFile <= 'd' )
+            return Board.Side.QUEENSIDE;
+
+        return Board.Side.KINGSIDE;
     }
 
     protected Piece( Player player, char startFile, char startRank )
     {
+        if ( !Board.isValidSquare( startFile, startRank ) )
+            throw new IllegalArgumentException();
+
         this.player = player;
 
         this.startFile = startFile;
@@ -80,30 +91,62 @@ public abstract class Piece
     public abstract int getValue();
 
     /**
-     * Returns the pseudo-legal moves available to this piece on the given board.
+     * Returns this piece's candidate squares on the given board.
      * <p>
-     * A pseudo-legal move obeys this piece's movement rules, but may leave the moving player's king
-     * in check.
+     * Candidate squares follow this piece's movement rules and are used as the basis for both
+     * controlled squares and pseudo-legal destination squares.
      * 
-     * @param board the chessboard
-     * @return the squares this piece could move to before checking king safety
+     * @param board                  the chessboard
+     * @param includeFriendlySquares whether to include squares occupied by friendly pieces
+     * @return this piece's candidate squares
      */
-    protected abstract List<Square> getPseudoLegalMoves( Board board );
+    protected abstract List<Square> getCandidateSquares( Board board, boolean includeFriendlySquares );
 
     /**
-     * Returns the legal moves available to this piece on the given board.
+     * Returns the squares controlled by this piece on the given board.
      * <p>
-     * Legal moves are obtained by filtering this piece's pseudo-legal moves to exclude any move
-     * that would leave the moving player's king in check.
+     * A square is controlled by this piece if this piece attacks or defends that square according
+     * to its movement rules, regardless of whether this piece could legally move there.
+     * 
+     * @param board the chessboard
+     * @return the squares controlled by this piece
+     */
+    public List<Square> getControlledSquares( Board board )
+    {
+        return getCandidateSquares( board, true );
+    }
+
+    /**
+     * Returns the pseudo-legal destination squares available to this piece on the given board.
+     * <p>
+     * Pseudo-legal destination squares follow this piece's movement rules and exclude squares
+     * occupied by friendly pieces. They are not filtered to exclude moves that would leave the
+     * moving player in check.
+     * 
+     * @param board the chessboard
+     * @return the squares this piece can pseudo-legally move to
+     */
+    private List<Square> getPseudoLegalMoves( Board board )
+    {
+        return getCandidateSquares( board, false );
+    }
+
+    /**
+     * Returns the legal destination squares available to this piece on the given board.
+     * <p>
+     * Legal destination squares are obtained by filtering this piece's pseudo-legal destination
+     * squares to exclude any move that would leave the moving player in check.
      * 
      * @param board the chessboard
      * @return the squares this piece can legally move to
      */
     public List<Square> getLegalMoves( Board board )
     {
+        Player player = getPlayer();
         Square from = getSquare( board );
+
         return getPseudoLegalMoves( board ).stream()
-                                           .filter( to -> !getPlayer().isInCheck( board.cloneAndMove( from, to ) ) )
+                                           .filter( to -> !board.moveWouldLeavePlayerInCheck( player, from, to ) )
                                            .toList();
     }
 
@@ -113,10 +156,10 @@ public abstract class Piece
     }
 
     /**
-     * Finds the square this piece is occupying.
+     * Returns the square occupied by this piece on the given board.
      * 
      * @param board the chessboard
-     * @return the square this piece is occupying (if it exists); {@code null} otherwise
+     * @return the square occupied by this piece, or {@code null} if this piece is not on the board
      */
     public Square getSquare( Board board )
     {
@@ -124,28 +167,28 @@ public abstract class Piece
     }
 
     /**
-     * Returns whether this piece is under attack by any opposing piece.
+     * Returns whether this piece is under attack.
+     * <p>
+     * A piece is under attack if the square it occupies is controlled by any opposing piece.
      * 
      * @param board the chessboard
-     * @return {@code true} if this piece is under attack by any opposing piece; {@code false}
-     *         otherwise
+     * @return {@code true} if this piece is under attack; {@code false} otherwise
      */
     public boolean isUnderAttack( Board board )
     {
-        return getSquare( board ).isPseudoLegallyReachableByOpponentOf( getPlayer(), board );
+        return getSquare( board ).isControlledByOpponentOf( getPlayer(), board );
     }
 
     /**
-     * Returns whether this piece could move to the given square before checking king safety.
+     * Returns whether this piece controls the given square.
      * 
-     * @param square the destination square
+     * @param square the square to check
      * @param board  the chessboard
-     * @return {@code true} if this piece could pseudo-legally move to the given square;
-     *         {@code false} otherwise
+     * @return {@code true} if this piece controls the given square; {@code false} otherwise
      */
-    public boolean canPseudoLegallyMoveTo( Square square, Board board )
+    public boolean controls( Square square, Board board )
     {
-        return getPseudoLegalMoves( board ).contains( square );
+        return getControlledSquares( board ).contains( square );
     }
 
     public boolean canPromote( Square square )
@@ -156,30 +199,19 @@ public abstract class Piece
     public boolean movedTwoSquaresForward( Square from, Square to )
     {
         return to.fileDiff( from ) == 0 &&
-               to.rankDiff( from ) == 2 * getSign();
+               to.rankDiff( from ) == 2 * getPlayerCoefficient();
     }
 
     public boolean movedOneSquareDiagonallyForward( Square from, Square to )
     {
         return Math.abs( to.fileDiff( from ) ) == 1 &&
-               to.rankDiff( from ) == getSign();
+               to.rankDiff( from ) == getPlayerCoefficient();
     }
 
     public boolean movedTwoSquaresHorizontally( Square from, Square to )
     {
         return Math.abs( to.fileDiff( from ) ) == 2 &&
                to.rankDiff( from ) == 0;
-    }
-
-    /**
-     * Returns a boolean indicating whether this piece is one of the given <b>types</b>.
-     * 
-     * @param types the piece types to check
-     * @return {@code true} if this piece is one of the given types; {@code false} otherwise
-     */
-    public boolean isType( Type... types )
-    {
-        return Arrays.asList( types ).contains( getType() );
     }
 
     public enum Type

--- a/src/main/java/io/github/ollybishop/bishopsgambit/pieces/Queen.java
+++ b/src/main/java/io/github/ollybishop/bishopsgambit/pieces/Queen.java
@@ -27,10 +27,10 @@ public class Queen extends Piece
     }
 
     @Override
-    public List<Square> getPseudoLegalMoves( Board board )
+    protected List<Square> getCandidateSquares( Board board, boolean includeFriendlySquares )
     {
-        List<Square> bishopMoves = Bishop.getPseudoLegalMoves( board, this );
-        List<Square> rookMoves = Rook.getPseudoLegalMoves( board, this );
-        return ListUtils.combine( bishopMoves, rookMoves );
+        List<Square> bishopCandidateSquares = Bishop.getCandidateSquares( this, board, includeFriendlySquares );
+        List<Square> rookCandidateSquares = Rook.getCandidateSquares( this, board, includeFriendlySquares );
+        return ListUtils.combine( bishopCandidateSquares, rookCandidateSquares );
     }
 }

--- a/src/main/java/io/github/ollybishop/bishopsgambit/pieces/Rook.java
+++ b/src/main/java/io/github/ollybishop/bishopsgambit/pieces/Rook.java
@@ -27,41 +27,41 @@ public class Rook extends Piece
     }
 
     @Override
-    public List<Square> getPseudoLegalMoves( Board board )
+    protected List<Square> getCandidateSquares( Board board, boolean includeFriendlySquares )
     {
-        return getPseudoLegalMoves( board, this );
+        return getCandidateSquares( this, board, includeFriendlySquares );
     }
 
-    public static List<Square> getPseudoLegalMoves( Board board, Piece piece )
+    protected static List<Square> getCandidateSquares( Piece piece, Board board, boolean includeFriendlySquares )
     {
-        List<Square> moves = new ArrayList<>();
+        List<Square> candidateSquares = new ArrayList<>();
 
         Square square = piece.getSquare( board );
 
-        for ( int x : new int[] { 0, 1 } )
+        for ( int dx : new int[] { 0, 1 } )
         {
-            for ( int y : new int[] { -1, 1 } )
+            for ( int dy : new int[] { -1, 1 } )
             {
                 for ( int n = 1; n < 8; n++ )
                 {
-                    Square s = square.travel( board, n * x * y, n * ( 1 - x ) * y );
+                    Square s = board.getSquare( square, n * dx * dy, n * ( 1 - dx ) * dy );
 
                     if ( s == null )
                         break;
 
                     if ( s.isOccupied() )
                     {
-                        if ( s.isOccupiedByOpponentOf( piece.getPlayer() ) )
-                            moves.add( s );
+                        if ( includeFriendlySquares || s.isOccupiedByOpponentOf( piece.getPlayer() ) )
+                            candidateSquares.add( s );
 
                         break;
                     }
 
-                    moves.add( s );
+                    candidateSquares.add( s );
                 }
             }
         }
 
-        return moves;
+        return candidateSquares;
     }
 }

--- a/src/main/java/io/github/ollybishop/bishopsgambit/player/Player.java
+++ b/src/main/java/io/github/ollybishop/bishopsgambit/player/Player.java
@@ -15,23 +15,17 @@ import io.github.ollybishop.bishopsgambit.pieces.Rook;
 public class Player
 {
     private final Colour colour;
-    private final int sign;
 
     private final List<Piece> pieces = new ArrayList<>();
 
     private final Rook queensideRook;
     private final Rook kingsideRook;
+
     private final King king;
 
     public Player( Colour colour )
     {
         this.colour = colour;
-
-        this.sign = switch ( colour )
-        {
-            case WHITE -> 1;
-            case BLACK -> -1;
-        };
 
         char backRank = switch ( colour )
         {
@@ -73,9 +67,13 @@ public class Player
         return this.colour;
     }
 
-    public int getSign()
+    public int getCoefficient()
     {
-        return this.sign;
+        return switch ( getColour() )
+        {
+            case WHITE -> 1;
+            case BLACK -> -1;
+        };
     }
 
     public List<Piece> getPieces()
@@ -94,22 +92,26 @@ public class Player
     }
 
     /**
-     * Returns the queenside or kingside rook belonging this player.
+     * Returns this player's original queenside or kingside rook, as indicated by the given castling
+     * direction.
+     * <p>
+     * The castling direction is the horizontal direction from the king's starting square towards
+     * the rook's starting square.
      * 
-     * @param x the direction along the x-axis of the rook's starting square (relative to the king's
-     *          starting square)
-     * @return the queenside rook if <b>x</b> is negative; the kingside rook if <b>x</b> is positive
-     * @throws IllegalArgumentException if <b>x</b> is zero
+     * @param castlingDirection the castling direction
+     * @return the queenside rook if {@code castlingDirection} is negative; the kingside rook if
+     *         {@code castlingDirection} is positive
+     * @throws IllegalArgumentException if {@code castlingDirection} is zero
      */
-    public Rook getRook( int x )
+    public Rook getRook( int castlingDirection )
     {
-        if ( x < 0 )
+        if ( castlingDirection < 0 )
             return getQueensideRook();
 
-        if ( x > 0 )
+        if ( castlingDirection > 0 )
             return getKingsideRook();
 
-        throw new IllegalArgumentException( "The value 'x' must be non-zero." );
+        throw new IllegalArgumentException( "Castling direction must be non-zero." );
     }
 
     public King getKing()

--- a/src/main/java/io/github/ollybishop/bishopsgambit/util/ListUtils.java
+++ b/src/main/java/io/github/ollybishop/bishopsgambit/util/ListUtils.java
@@ -16,20 +16,20 @@ public class ListUtils
     }
 
     /**
-     * Finds the element in <b>list1</b> that has the same index as the given <b>object</b> in
-     * <b>list2</b>.
+     * Returns the element in {@code list1} at the same index as the first occurrence of
+     * {@code element} in {@code list2}.
      * 
-     * @param <T>    the type of the element to be found
-     * @param <U>    the type of the given <b>object</b>
-     * @param list1  the list containing the element to be found
-     * @param list2  the list containing the given <b>object</b>
-     * @param object the object whose index we are interested in
-     * @return the element in <b>list1</b> that has the same index as the given <b>object</b> in
-     *         <b>list2</b> (if it exists); {@code null} otherwise
+     * @param <T>     the type of elements in {@code list1}
+     * @param <U>     the type of elements in {@code list2}
+     * @param list1   the list containing the element to return
+     * @param list2   the list to search for {@code element}
+     * @param element the element to search for in {@code list2}
+     * @return the element in {@code list1} at the same index as the first occurrence of
+     *         {@code element} in {@code list2}, if such an element exists; {@code null} otherwise
      */
-    public static <T, U> T get( List<T> list1, List<U> list2, U object )
+    public static <T, U> T getCorrespondingElement( List<T> list1, List<U> list2, U element )
     {
-        int index = list2.indexOf( object );
+        int index = list2.indexOf( element );
 
         if ( hasIndex( list1, index ) )
             return list1.get( index );

--- a/src/test/java/io/github/ollybishop/bishopsgambit/game/GameTest.java
+++ b/src/test/java/io/github/ollybishop/bishopsgambit/game/GameTest.java
@@ -7,12 +7,13 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.util.List;
+
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInfo;
 
-import io.github.ollybishop.bishopsgambit.board.Board;
 import io.github.ollybishop.bishopsgambit.board.Square;
 import io.github.ollybishop.bishopsgambit.pieces.Piece;
 import io.github.ollybishop.bishopsgambit.player.Player;
@@ -20,6 +21,70 @@ import io.github.ollybishop.bishopsgambit.player.Player;
 class GameTest
 {
     private Game game;
+
+    // ============================================================================================
+
+    private final SquareHelper a1 = new SquareHelper( 'a', '1' );
+    private final SquareHelper a2 = new SquareHelper( 'a', '2' );
+    private final SquareHelper a3 = new SquareHelper( 'a', '3' );
+    private final SquareHelper a4 = new SquareHelper( 'a', '4' );
+    private final SquareHelper a5 = new SquareHelper( 'a', '5' );
+    private final SquareHelper a6 = new SquareHelper( 'a', '6' );
+    private final SquareHelper a7 = new SquareHelper( 'a', '7' );
+    private final SquareHelper a8 = new SquareHelper( 'a', '8' );
+
+    private final SquareHelper b1 = new SquareHelper( 'b', '1' );
+    private final SquareHelper b2 = new SquareHelper( 'b', '2' );
+    private final SquareHelper b3 = new SquareHelper( 'b', '3' );
+    private final SquareHelper b6 = new SquareHelper( 'b', '6' );
+    private final SquareHelper b7 = new SquareHelper( 'b', '7' );
+    private final SquareHelper b8 = new SquareHelper( 'b', '8' );
+
+    private final SquareHelper c1 = new SquareHelper( 'c', '1' );
+    private final SquareHelper c2 = new SquareHelper( 'c', '2' );
+    private final SquareHelper c3 = new SquareHelper( 'c', '3' );
+    private final SquareHelper c6 = new SquareHelper( 'c', '6' );
+    private final SquareHelper c7 = new SquareHelper( 'c', '7' );
+    private final SquareHelper c8 = new SquareHelper( 'c', '8' );
+
+    private final SquareHelper d1 = new SquareHelper( 'd', '1' );
+    private final SquareHelper d2 = new SquareHelper( 'd', '2' );
+    private final SquareHelper d3 = new SquareHelper( 'd', '3' );
+    private final SquareHelper d6 = new SquareHelper( 'd', '6' );
+    private final SquareHelper d7 = new SquareHelper( 'd', '7' );
+    private final SquareHelper d8 = new SquareHelper( 'd', '8' );
+
+    private final SquareHelper e1 = new SquareHelper( 'e', '1' );
+    private final SquareHelper e2 = new SquareHelper( 'e', '2' );
+    private final SquareHelper e3 = new SquareHelper( 'e', '3' );
+    private final SquareHelper e4 = new SquareHelper( 'e', '4' );
+    private final SquareHelper e5 = new SquareHelper( 'e', '5' );
+    private final SquareHelper e6 = new SquareHelper( 'e', '6' );
+    private final SquareHelper e7 = new SquareHelper( 'e', '7' );
+    private final SquareHelper e8 = new SquareHelper( 'e', '8' );
+
+    private final SquareHelper f1 = new SquareHelper( 'f', '1' );
+    private final SquareHelper f2 = new SquareHelper( 'f', '2' );
+    private final SquareHelper f3 = new SquareHelper( 'f', '3' );
+    private final SquareHelper f6 = new SquareHelper( 'f', '6' );
+    private final SquareHelper f7 = new SquareHelper( 'f', '7' );
+    private final SquareHelper f8 = new SquareHelper( 'f', '8' );
+
+    private final SquareHelper g1 = new SquareHelper( 'g', '1' );
+    private final SquareHelper g2 = new SquareHelper( 'g', '2' );
+    private final SquareHelper g3 = new SquareHelper( 'g', '3' );
+    private final SquareHelper g6 = new SquareHelper( 'g', '6' );
+    private final SquareHelper g7 = new SquareHelper( 'g', '7' );
+    private final SquareHelper g8 = new SquareHelper( 'g', '8' );
+
+    private final SquareHelper h1 = new SquareHelper( 'h', '1' );
+    private final SquareHelper h2 = new SquareHelper( 'h', '2' );
+    private final SquareHelper h3 = new SquareHelper( 'h', '3' );
+    private final SquareHelper h4 = new SquareHelper( 'h', '4' );
+    private final SquareHelper h5 = new SquareHelper( 'h', '5' );
+    private final SquareHelper h6 = new SquareHelper( 'h', '6' );
+    private final SquareHelper h7 = new SquareHelper( 'h', '7' );
+    private final SquareHelper h8 = new SquareHelper( 'h', '8' );
 
     // ============================================================================================
 
@@ -34,31 +99,9 @@ class GameTest
         makeMove( uci2 );
     }
 
-    private void makeMove( Square from, Square to, Piece.Type newType )
+    private void makeMove( SquareHelper from, SquareHelper to, Piece.Type newType )
     {
-        game.makeMove( from, to, newType );
-    }
-
-    // ============================================================================================
-
-    private Board getActiveBoard()
-    {
-        return game.getActiveBoard();
-    }
-
-    private Player getActivePlayer()
-    {
-        return game.getActivePlayer();
-    }
-
-    private Square getSquare( String coords )
-    {
-        return getActiveBoard().getSquare( coords );
-    }
-
-    private Piece getPiece( String coords )
-    {
-        return getSquare( coords ).getPiece();
+        game.makeMove( from.getSquare(), to.getSquare(), newType );
     }
 
     // ============================================================================================
@@ -70,34 +113,34 @@ class GameTest
 
     private int getNumberOfLegalMoves()
     {
-        return getActivePlayer().getNumberOfLegalMoves( getActiveBoard() );
+        return game.getActivePlayer().getNumberOfLegalMoves( game.getActiveBoard() );
     }
 
     private int getMaterialDifference()
     {
-        return getActiveBoard().getMaterialDifference();
+        return game.getActiveBoard().getMaterialDifference();
     }
 
     // ============================================================================================
 
     private boolean isInCheck()
     {
-        return getActivePlayer().isInCheck( getActiveBoard() );
+        return game.getActivePlayer().isInCheck( game.getActiveBoard() );
     }
 
     private boolean isCheckmated()
     {
-        return getActivePlayer().isCheckmated( getActiveBoard() );
+        return game.getActivePlayer().isCheckmated( game.getActiveBoard() );
     }
 
     private boolean isStalemated()
     {
-        return getActivePlayer().isStalemated( getActiveBoard() );
+        return game.getActivePlayer().isStalemated( game.getActiveBoard() );
     }
 
     private boolean hasInsufficientMaterial()
     {
-        return getActiveBoard().hasInsufficientMaterial();
+        return game.getActiveBoard().hasInsufficientMaterial();
     }
 
     private Game.Status getStatus()
@@ -109,22 +152,22 @@ class GameTest
 
     private boolean isWhiteQueensideCastlingAllowed()
     {
-        return getActiveBoard().isWhiteQueensideCastlingAllowed();
+        return game.getActiveBoard().isWhiteQueensideCastlingAllowed();
     }
 
     private boolean isWhiteKingsideCastlingAllowed()
     {
-        return getActiveBoard().isWhiteKingsideCastlingAllowed();
+        return game.getActiveBoard().isWhiteKingsideCastlingAllowed();
     }
 
     private boolean isBlackQueensideCastlingAllowed()
     {
-        return getActiveBoard().isBlackQueensideCastlingAllowed();
+        return game.getActiveBoard().isBlackQueensideCastlingAllowed();
     }
 
     private boolean isBlackKingsideCastlingAllowed()
     {
-        return getActiveBoard().isBlackKingsideCastlingAllowed();
+        return game.getActiveBoard().isBlackKingsideCastlingAllowed();
     }
 
     // ============================================================================================
@@ -144,10 +187,12 @@ class GameTest
     @AfterEach
     void printBoard()
     {
-        getActiveBoard().print();
+        game.getActiveBoard().print();
         System.out.println();
     }
 
+    // ============================================================================================
+    // Invalid Moves
     // ============================================================================================
 
     @Test
@@ -165,6 +210,10 @@ class GameTest
                                  () -> makeMove( "e1e2" ),
                                  "The White King occupying e1 cannot legally move to e2." );
     }
+
+    // ============================================================================================
+    // Checkmate
+    // ============================================================================================
 
     @Test
     void checkmate_foolsMate()
@@ -202,13 +251,17 @@ class GameTest
         assertEquals( getStatus(), Game.Status.CHECKMATE );
     }
 
+    // ============================================================================================
+    // Castling
+    // ============================================================================================
+
     @Test
     void kingsideCastling()
     {
-        Piece whiteKing = getPiece( "e1" );
-        Piece blackKing = getPiece( "e8" );
-        Piece whiteKingsideRook = getPiece( "h1" );
-        Piece blackKingsideRook = getPiece( "h8" );
+        Piece whiteKing = e1.getPiece();
+        Piece blackKing = e8.getPiece();
+        Piece whiteKingsideRook = h1.getPiece();
+        Piece blackKingsideRook = h8.getPiece();
 
         makeMove( "e2e4", "e7e5" );
         makeMove( "g1f3", "g8f6" );
@@ -225,19 +278,19 @@ class GameTest
         assertFalse( hasInsufficientMaterial() );
         assertEquals( getStatus(), Game.Status.DEFAULT );
 
-        assertSameNotNull( whiteKing, getPiece( "g1" ) );
-        assertSameNotNull( blackKing, getPiece( "g8" ) );
-        assertSameNotNull( whiteKingsideRook, getPiece( "f1" ) );
-        assertSameNotNull( blackKingsideRook, getPiece( "f8" ) );
+        assertSameNotNull( whiteKing, g1.getPiece() );
+        assertSameNotNull( blackKing, g8.getPiece() );
+        assertSameNotNull( whiteKingsideRook, f1.getPiece() );
+        assertSameNotNull( blackKingsideRook, f8.getPiece() );
     }
 
     @Test
     void queensideCastling()
     {
-        Piece whiteKing = getPiece( "e1" );
-        Piece blackKing = getPiece( "e8" );
-        Piece whiteQueensideRook = getPiece( "a1" );
-        Piece blackQueensideRook = getPiece( "a8" );
+        Piece whiteKing = e1.getPiece();
+        Piece blackKing = e8.getPiece();
+        Piece whiteQueensideRook = a1.getPiece();
+        Piece blackQueensideRook = a8.getPiece();
 
         makeMove( "d2d4", "d7d5" );
         makeMove( "b1c3", "b8c6" );
@@ -255,17 +308,112 @@ class GameTest
         assertFalse( hasInsufficientMaterial() );
         assertEquals( getStatus(), Game.Status.DEFAULT );
 
-        assertSameNotNull( whiteKing, getPiece( "c1" ) );
-        assertSameNotNull( blackKing, getPiece( "c8" ) );
-        assertSameNotNull( whiteQueensideRook, getPiece( "d1" ) );
-        assertSameNotNull( blackQueensideRook, getPiece( "d8" ) );
+        assertSameNotNull( whiteKing, c1.getPiece() );
+        assertSameNotNull( blackKing, c8.getPiece() );
+        assertSameNotNull( whiteQueensideRook, d1.getPiece() );
+        assertSameNotNull( blackQueensideRook, d8.getPiece() );
     }
+
+    @Test
+    void kingsideCastling_fSquareOccupied_byEnemyKnight_illegalMoveException()
+    {
+        makeMove( "e2e4", "g8f6" );
+        makeMove( "g1f3", "f6g4" );
+        makeMove( "f1c4", "g4e3" );
+        makeMove( "d2d3", "e3f1" );
+
+        Piece blackKnight = f1.getPiece();
+        assertEquals( blackKnight.getColour(), Player.Colour.BLACK );
+        assertEquals( blackKnight.getType(), Piece.Type.KNIGHT );
+
+        assertThrowsWithMessage( IllegalMoveException.class,
+                                 () -> makeMove( "e1g1" ),
+                                 "The White King occupying e1 cannot legally move to g1." );
+
+        assertEquals( 8, getNumberOfPliesPlayed() );
+        assertEquals( 37, getNumberOfLegalMoves() );
+        assertEquals( 0, getMaterialDifference() );
+
+        assertFalse( isInCheck() );
+        assertFalse( isCheckmated() );
+        assertFalse( isStalemated() );
+        assertFalse( hasInsufficientMaterial() );
+        assertEquals( getStatus(), Game.Status.DEFAULT );
+    }
+
+    @Test
+    void kingsideCastling_fSquareOccupied_byEnemyBishop_illegalMoveException()
+    {
+        makeMove( "e2e4", "b7b6" );
+        makeMove( "g1f3", "c8a6" );
+        makeMove( "d2d4", "a6f1" );
+
+        Piece blackBishop = f1.getPiece();
+        assertEquals( blackBishop.getColour(), Player.Colour.BLACK );
+        assertEquals( blackBishop.getType(), Piece.Type.BISHOP );
+
+        assertThrowsWithMessage( IllegalMoveException.class,
+                                 () -> makeMove( "e1g1" ),
+                                 "The White King occupying e1 cannot legally move to g1." );
+
+        assertEquals( 6, getNumberOfPliesPlayed() );
+        assertEquals( 32, getNumberOfLegalMoves() );
+        assertEquals( -3, getMaterialDifference() );
+
+        assertFalse( isInCheck() );
+        assertFalse( isCheckmated() );
+        assertFalse( isStalemated() );
+        assertFalse( hasInsufficientMaterial() );
+        assertEquals( getStatus(), Game.Status.DEFAULT );
+    }
+
+    @Test
+    void kingsideCastling_fSquareControlled_byEnemyPawn_illegalMoveException()
+    {
+        makeMove( "d2d4", "g8f6" );
+        makeMove( "d4d5", "e7e5" );
+        makeMove( "d5e6", "f8c5" );
+        makeMove( "e6e7" );
+
+        Piece whiteDPawn = e7.getPiece();
+        assertEquals( whiteDPawn.getColour(), Player.Colour.WHITE );
+        assertEquals( whiteDPawn.getType(), Piece.Type.PAWN );
+
+        assertThrowsWithMessage( IllegalMoveException.class,
+                                 () -> makeMove( "e8g8" ),
+                                 "The Black King occupying e8 cannot legally move to g8." );
+    }
+
+    @Test
+    void kingsideCastling_gSquareControlled_byEnemyPawn_illegalMoveException()
+    {
+        makeMove( "g2g4", "g8f6" );
+        makeMove( "g4g5", "e7e5" );
+        makeMove( "g5g6", "f8c5" );
+        makeMove( "g6h7" );
+
+        Piece whiteGPawn = h7.getPiece();
+        assertEquals( whiteGPawn.getColour(), Player.Colour.WHITE );
+        assertEquals( whiteGPawn.getType(), Piece.Type.PAWN );
+
+        assertThrowsWithMessage( IllegalMoveException.class,
+                                 () -> makeMove( "e8g8" ),
+                                 "The Black King occupying e8 cannot legally move to g8." );
+    }
+
+    // ============================================================================================
+    // En Passant
+    // ============================================================================================
 
     @Test
     void enPassant_illegalMoveException()
     {
         makeMove( "d2d4", "e7e6" );
         makeMove( "d4d5", "e6e5" );
+
+        assertThrowsWithMessage( IllegalMoveException.class,
+                                 () -> makeMove( "d5e6" ),
+                                 "The White Pawn occupying d5 cannot legally move to e6." );
 
         assertEquals( 4, getNumberOfPliesPlayed() );
         assertEquals( 29, getNumberOfLegalMoves() );
@@ -276,10 +424,6 @@ class GameTest
         assertFalse( isStalemated() );
         assertFalse( hasInsufficientMaterial() );
         assertEquals( getStatus(), Game.Status.DEFAULT );
-
-        assertThrowsWithMessage( IllegalMoveException.class,
-                                 () -> makeMove( "d5e6" ),
-                                 "The White Pawn occupying d5 cannot legally move to e6." );
     }
 
     @Test
@@ -304,61 +448,12 @@ class GameTest
         assertDoesNotThrow( () -> makeMove( "e5d6" ) );
     }
 
-    @Test
-    void kingsideCastling_fSquareOccupied_byEnemyKnight_illegalMoveException()
-    {
-        makeMove( "e2e4", "g8f6" );
-        makeMove( "g1f3", "f6g4" );
-        makeMove( "f1c4", "g4e3" );
-        makeMove( "d2d3", "e3f1" );
-
-        assertEquals( 8, getNumberOfPliesPlayed() );
-        assertEquals( 37, getNumberOfLegalMoves() );
-        assertEquals( 0, getMaterialDifference() );
-
-        assertFalse( isInCheck() );
-        assertFalse( isCheckmated() );
-        assertFalse( isStalemated() );
-        assertFalse( hasInsufficientMaterial() );
-        assertEquals( getStatus(), Game.Status.DEFAULT );
-
-        assertThrowsWithMessage( IllegalMoveException.class,
-                                 () -> makeMove( "e1g1" ),
-                                 "The White King occupying e1 cannot legally move to g1." );
-
-        Piece piece = getPiece( "f1" );
-        assertEquals( piece.getColour(), Player.Colour.BLACK );
-        assertEquals( piece.getType(), Piece.Type.KNIGHT );
-    }
+    // ============================================================================================
+    // Stalemate
+    // ============================================================================================
 
     @Test
-    void kingsideCastling_fSquareOccupied_byEnemyBishop_illegalMoveException()
-    {
-        makeMove( "e2e4", "b7b6" );
-        makeMove( "g1f3", "c8a6" );
-        makeMove( "d2d4", "a6f1" );
-
-        assertEquals( 6, getNumberOfPliesPlayed() );
-        assertEquals( 32, getNumberOfLegalMoves() );
-        assertEquals( -3, getMaterialDifference() );
-
-        assertFalse( isInCheck() );
-        assertFalse( isCheckmated() );
-        assertFalse( isStalemated() );
-        assertFalse( hasInsufficientMaterial() );
-        assertEquals( getStatus(), Game.Status.DEFAULT );
-
-        assertThrowsWithMessage( IllegalMoveException.class,
-                                 () -> makeMove( "e1g1" ),
-                                 "The White King occupying e1 cannot legally move to g1." );
-
-        Piece piece = getPiece( "f1" );
-        assertEquals( piece.getColour(), Player.Colour.BLACK );
-        assertEquals( piece.getType(), Piece.Type.BISHOP );
-    }
-
-    @Test
-    void stalemate_nineteenTurns()
+    void stalemate_nineteenPlies()
     {
         makeMove( "e2e3", "a7a5" );
         makeMove( "d1h5", "a8a6" );
@@ -383,7 +478,7 @@ class GameTest
     }
 
     @Test
-    void stalemate_twentyFourTurns_noCaptures()
+    void stalemate_twentyFourPlies_noCaptures()
     {
         makeMove( "d2d4", "e7e5" ); // 1. d4, d5
         makeMove( "d1d2", "e5e4" ); // 2. Qd2, e4
@@ -408,6 +503,10 @@ class GameTest
         assertFalse( hasInsufficientMaterial() );
         assertEquals( getStatus(), Game.Status.STALEMATE );
     }
+
+    // ============================================================================================
+    // Insufficient Material
+    // ============================================================================================
 
     @Test
     void insufficientMaterial_kingVersusKing()
@@ -538,6 +637,10 @@ class GameTest
         assertEquals( getStatus(), Game.Status.INSUFFICIENT_MATERIAL );
     }
 
+    // ============================================================================================
+    // Revoke Castling Rights
+    // ============================================================================================
+
     @Test
     void revokeCastlingRights_byMovingQueensideRook()
     {
@@ -602,6 +705,10 @@ class GameTest
         assertFalse( isBlackKingsideCastlingAllowed() );
     }
 
+    // ============================================================================================
+    // Pawn Promotion
+    // ============================================================================================
+
     @Test
     void pawnPromotion_newPieceTypeQueen()
     {
@@ -611,13 +718,13 @@ class GameTest
         makeMove( "c6b7", "f3g2" );
         makeMove( "b7a8q", "g2h1q" );
 
-        Piece newPieceWhite = getPiece( "a8" );
-        assertEquals( newPieceWhite.getColour(), Player.Colour.WHITE );
-        assertEquals( newPieceWhite.getType(), Piece.Type.QUEEN );
+        Piece whiteQueen = a8.getPiece();
+        assertEquals( whiteQueen.getColour(), Player.Colour.WHITE );
+        assertEquals( whiteQueen.getType(), Piece.Type.QUEEN );
 
-        Piece newPieceBlack = getPiece( "h1" );
-        assertEquals( newPieceBlack.getColour(), Player.Colour.BLACK );
-        assertEquals( newPieceBlack.getType(), Piece.Type.QUEEN );
+        Piece blackQueen = h1.getPiece();
+        assertEquals( blackQueen.getColour(), Player.Colour.BLACK );
+        assertEquals( blackQueen.getType(), Piece.Type.QUEEN );
     }
 
     @Test
@@ -629,13 +736,13 @@ class GameTest
         makeMove( "c6b7", "f3g2" );
         makeMove( "b7a8r", "g2h1r" );
 
-        Piece newPieceWhite = getPiece( "a8" );
-        assertEquals( newPieceWhite.getColour(), Player.Colour.WHITE );
-        assertEquals( newPieceWhite.getType(), Piece.Type.ROOK );
+        Piece whiteRook = a8.getPiece();
+        assertEquals( whiteRook.getColour(), Player.Colour.WHITE );
+        assertEquals( whiteRook.getType(), Piece.Type.ROOK );
 
-        Piece newPieceBlack = getPiece( "h1" );
-        assertEquals( newPieceBlack.getColour(), Player.Colour.BLACK );
-        assertEquals( newPieceBlack.getType(), Piece.Type.ROOK );
+        Piece blackRook = h1.getPiece();
+        assertEquals( blackRook.getColour(), Player.Colour.BLACK );
+        assertEquals( blackRook.getType(), Piece.Type.ROOK );
     }
 
     @Test
@@ -647,13 +754,13 @@ class GameTest
         makeMove( "c6b7", "f3g2" );
         makeMove( "b7a8b", "g2h1b" );
 
-        Piece newPieceWhite = getPiece( "a8" );
-        assertEquals( newPieceWhite.getColour(), Player.Colour.WHITE );
-        assertEquals( newPieceWhite.getType(), Piece.Type.BISHOP );
+        Piece whiteBishop = a8.getPiece();
+        assertEquals( whiteBishop.getColour(), Player.Colour.WHITE );
+        assertEquals( whiteBishop.getType(), Piece.Type.BISHOP );
 
-        Piece newPieceBlack = getPiece( "h1" );
-        assertEquals( newPieceBlack.getColour(), Player.Colour.BLACK );
-        assertEquals( newPieceBlack.getType(), Piece.Type.BISHOP );
+        Piece blackBishop = h1.getPiece();
+        assertEquals( blackBishop.getColour(), Player.Colour.BLACK );
+        assertEquals( blackBishop.getType(), Piece.Type.BISHOP );
     }
 
     @Test
@@ -665,13 +772,13 @@ class GameTest
         makeMove( "c6b7", "f3g2" );
         makeMove( "b7a8n", "g2h1n" );
 
-        Piece newPieceWhite = getPiece( "a8" );
-        assertEquals( newPieceWhite.getColour(), Player.Colour.WHITE );
-        assertEquals( newPieceWhite.getType(), Piece.Type.KNIGHT );
+        Piece whiteKnight = a8.getPiece();
+        assertEquals( whiteKnight.getColour(), Player.Colour.WHITE );
+        assertEquals( whiteKnight.getType(), Piece.Type.KNIGHT );
 
-        Piece newPieceBlack = getPiece( "h1" );
-        assertEquals( newPieceBlack.getColour(), Player.Colour.BLACK );
-        assertEquals( newPieceBlack.getType(), Piece.Type.KNIGHT );
+        Piece blackKnight = h1.getPiece();
+        assertEquals( blackKnight.getColour(), Player.Colour.BLACK );
+        assertEquals( blackKnight.getType(), Piece.Type.KNIGHT );
     }
 
     @Test
@@ -682,12 +789,9 @@ class GameTest
         makeMove( "c5c6", "f4f3" );
         makeMove( "c6b7", "f3g2" );
 
-        Square from = getSquare( "b7" );
-        Square to = getSquare( "a8" );
-
         // Attempt to promote a pawn to a pawn
         assertThrowsWithMessage( InvalidPromotionException.class,
-                                 () -> makeMove( from, to, Piece.Type.PAWN ),
+                                 () -> makeMove( b7, a8, Piece.Type.PAWN ),
                                  "The new piece type (Pawn) must be one of Knight, Bishop, Rook or Queen." );
     }
 
@@ -699,12 +803,9 @@ class GameTest
         makeMove( "c5c6", "f4f3" );
         makeMove( "c6b7", "f3g2" );
 
-        Square from = getSquare( "b7" );
-        Square to = getSquare( "a8" );
-
         // Attempt to promote a pawn to a king
         assertThrowsWithMessage( InvalidPromotionException.class,
-                                 () -> makeMove( from, to, Piece.Type.KING ),
+                                 () -> makeMove( b7, a8, Piece.Type.KING ),
                                  "The new piece type (King) must be one of Knight, Bishop, Rook or Queen." );
     }
 
@@ -741,5 +842,338 @@ class GameTest
         assertThrowsWithMessage( InvalidPromotionException.class,
                                  () -> makeMove( "c2c4q" ),
                                  "The promotion square (c4) must be on White's last rank." );
+    }
+
+    // ============================================================================================
+    // Controlled Squares
+    // ============================================================================================
+
+    // Pawns
+
+    @Test
+    void initialSetup_whiteAPawn_controlsRightDiagonalOnly()
+    {
+        PieceHelper whiteAPawn = a2.getPieceHelper();
+
+        assertEquals( 1, whiteAPawn.getControlledSquares().size() );
+
+        assertFalse( whiteAPawn.controls( a3 ) );
+        assertFalse( whiteAPawn.controls( a4 ) );
+        assertTrue( whiteAPawn.controls( b3 ) );
+    }
+
+    @Test
+    void initialSetup_whiteEPawn_controlsDiagonalsOnly()
+    {
+        PieceHelper whiteEPawn = e2.getPieceHelper();
+
+        assertEquals( 2, whiteEPawn.getControlledSquares().size() );
+
+        assertTrue( whiteEPawn.controls( d3 ) );
+        assertFalse( whiteEPawn.controls( e3 ) );
+        assertFalse( whiteEPawn.controls( e4 ) );
+        assertTrue( whiteEPawn.controls( f3 ) );
+    }
+
+    @Test
+    void initialSetup_whiteHPawn_controlsDiagonalsOnly()
+    {
+        PieceHelper whiteHPawn = h2.getPieceHelper();
+
+        assertEquals( 1, whiteHPawn.getControlledSquares().size() );
+
+        assertTrue( whiteHPawn.controls( g3 ) );
+        assertFalse( whiteHPawn.controls( h3 ) );
+        assertFalse( whiteHPawn.controls( h4 ) );
+    }
+
+    @Test
+    void initialSetup_blackAPawn_controlsRightDiagonalOnly()
+    {
+        PieceHelper blackAPawn = a7.getPieceHelper();
+
+        assertEquals( 1, blackAPawn.getControlledSquares().size() );
+
+        assertFalse( blackAPawn.controls( a6 ) );
+        assertFalse( blackAPawn.controls( a5 ) );
+        assertTrue( blackAPawn.controls( b6 ) );
+    }
+
+    @Test
+    void initialSetup_blackEPawn_controlsDiagonalsOnly()
+    {
+        PieceHelper blackEPawn = e7.getPieceHelper();
+
+        assertEquals( 2, blackEPawn.getControlledSquares().size() );
+
+        assertTrue( blackEPawn.controls( d6 ) );
+        assertFalse( blackEPawn.controls( e6 ) );
+        assertFalse( blackEPawn.controls( e5 ) );
+        assertTrue( blackEPawn.controls( f6 ) );
+    }
+
+    @Test
+    void initialSetup_blackHPawn_controlsDiagonalsOnly()
+    {
+        PieceHelper blackHPawn = h7.getPieceHelper();
+
+        assertEquals( 1, blackHPawn.getControlledSquares().size() );
+
+        assertTrue( blackHPawn.controls( g6 ) );
+        assertFalse( blackHPawn.controls( h6 ) );
+        assertFalse( blackHPawn.controls( h5 ) );
+    }
+
+    // Knights
+
+    @Test
+    void initialSetup_whiteQueensideKnight_controlledSquares()
+    {
+        PieceHelper whiteQueensideKnight = b1.getPieceHelper();
+
+        assertEquals( 3, whiteQueensideKnight.getControlledSquares().size() );
+
+        assertTrue( whiteQueensideKnight.controls( a3 ) );
+        assertTrue( whiteQueensideKnight.controls( c3 ) );
+        assertTrue( whiteQueensideKnight.controls( d2 ) );
+    }
+
+    @Test
+    void initialSetup_whiteKingsideKnight_controlledSquares()
+    {
+        PieceHelper whiteKingsideKnight = g1.getPieceHelper();
+
+        assertEquals( 3, whiteKingsideKnight.getControlledSquares().size() );
+
+        assertTrue( whiteKingsideKnight.controls( e2 ) );
+        assertTrue( whiteKingsideKnight.controls( f3 ) );
+        assertTrue( whiteKingsideKnight.controls( h3 ) );
+    }
+
+    @Test
+    void initialSetup_blackQueensideKnight_controlledSquares()
+    {
+        PieceHelper blackQueensideKnight = b8.getPieceHelper();
+
+        assertEquals( 3, blackQueensideKnight.getControlledSquares().size() );
+
+        assertTrue( blackQueensideKnight.controls( a6 ) );
+        assertTrue( blackQueensideKnight.controls( c6 ) );
+        assertTrue( blackQueensideKnight.controls( d7 ) );
+    }
+
+    @Test
+    void initialSetup_blackKingsideKnight_controlledSquares()
+    {
+        PieceHelper blackKingsideKnight = g8.getPieceHelper();
+
+        assertEquals( 3, blackKingsideKnight.getControlledSquares().size() );
+
+        assertTrue( blackKingsideKnight.controls( e7 ) );
+        assertTrue( blackKingsideKnight.controls( f6 ) );
+        assertTrue( blackKingsideKnight.controls( h6 ) );
+    }
+
+    // Bishops
+
+    @Test
+    void initialSetup_whiteQueensideBishop_controlledSquares()
+    {
+        PieceHelper whiteQueensideBishop = c1.getPieceHelper();
+
+        assertEquals( 2, whiteQueensideBishop.getControlledSquares().size() );
+
+        assertTrue( whiteQueensideBishop.controls( b2 ) );
+        assertTrue( whiteQueensideBishop.controls( d2 ) );
+    }
+
+    @Test
+    void initialSetup_whiteKingsideBishop_controlledSquares()
+    {
+        PieceHelper whiteKingsideBishop = f1.getPieceHelper();
+
+        assertEquals( 2, whiteKingsideBishop.getControlledSquares().size() );
+
+        assertTrue( whiteKingsideBishop.controls( e2 ) );
+        assertTrue( whiteKingsideBishop.controls( g2 ) );
+    }
+
+    @Test
+    void initialSetup_blackQueensideBishop_controlledSquares()
+    {
+        PieceHelper blackQueensideBishop = c8.getPieceHelper();
+
+        assertEquals( 2, blackQueensideBishop.getControlledSquares().size() );
+
+        assertTrue( blackQueensideBishop.controls( b7 ) );
+        assertTrue( blackQueensideBishop.controls( d7 ) );
+    }
+
+    @Test
+    void initialSetup_blackKingsideBishop_controlledSquares()
+    {
+        PieceHelper blackKingsideBishop = f8.getPieceHelper();
+
+        assertEquals( 2, blackKingsideBishop.getControlledSquares().size() );
+
+        assertTrue( blackKingsideBishop.controls( e7 ) );
+        assertTrue( blackKingsideBishop.controls( g7 ) );
+    }
+
+    // Rooks
+
+    @Test
+    void initialSetup_whiteQueensideRook_controlledSquares()
+    {
+        PieceHelper whiteQueensideRook = a1.getPieceHelper();
+
+        assertEquals( 2, whiteQueensideRook.getControlledSquares().size() );
+
+        assertTrue( whiteQueensideRook.controls( a2 ) );
+        assertTrue( whiteQueensideRook.controls( b1 ) );
+    }
+
+    @Test
+    void initialSetup_whiteKingsideRook_controlledSquares()
+    {
+        PieceHelper whiteKingsideRook = h1.getPieceHelper();
+
+        assertEquals( 2, whiteKingsideRook.getControlledSquares().size() );
+
+        assertTrue( whiteKingsideRook.controls( g1 ) );
+        assertTrue( whiteKingsideRook.controls( h2 ) );
+    }
+
+    @Test
+    void initialSetup_blackQueensideRook_controlledSquares()
+    {
+        PieceHelper blackQueensideRook = a8.getPieceHelper();
+
+        assertEquals( 2, blackQueensideRook.getControlledSquares().size() );
+
+        assertTrue( blackQueensideRook.controls( a7 ) );
+        assertTrue( blackQueensideRook.controls( b8 ) );
+    }
+
+    @Test
+    void initialSetup_blackKingsideRook_controlledSquares()
+    {
+        PieceHelper blackKingsideRook = h8.getPieceHelper();
+
+        assertEquals( 2, blackKingsideRook.getControlledSquares().size() );
+
+        assertTrue( blackKingsideRook.controls( g8 ) );
+        assertTrue( blackKingsideRook.controls( h7 ) );
+    }
+
+    // Queens
+
+    @Test
+    void initialSetup_whiteQueen_controlledSquares()
+    {
+        PieceHelper whiteQueen = d1.getPieceHelper();
+
+        assertEquals( 5, whiteQueen.getControlledSquares().size() );
+
+        assertTrue( whiteQueen.controls( c1 ) );
+        assertTrue( whiteQueen.controls( c2 ) );
+        assertTrue( whiteQueen.controls( d2 ) );
+        assertTrue( whiteQueen.controls( e1 ) );
+        assertTrue( whiteQueen.controls( e2 ) );
+    }
+
+    @Test
+    void initialSetup_blackQueen_controlledSquares()
+    {
+        PieceHelper blackQueen = d8.getPieceHelper();
+
+        assertEquals( 5, blackQueen.getControlledSquares().size() );
+
+        assertTrue( blackQueen.controls( c8 ) );
+        assertTrue( blackQueen.controls( c7 ) );
+        assertTrue( blackQueen.controls( d7 ) );
+        assertTrue( blackQueen.controls( e8 ) );
+        assertTrue( blackQueen.controls( e7 ) );
+    }
+
+    // Kings
+
+    @Test
+    void initialSetup_whiteKing_controlledSquares()
+    {
+        PieceHelper whiteKing = e1.getPieceHelper();
+
+        assertEquals( 5, whiteKing.getControlledSquares().size() );
+
+        assertTrue( whiteKing.controls( d1 ) );
+        assertTrue( whiteKing.controls( d2 ) );
+        assertTrue( whiteKing.controls( e2 ) );
+        assertTrue( whiteKing.controls( f1 ) );
+        assertTrue( whiteKing.controls( f2 ) );
+    }
+
+    @Test
+    void initialSetup_blackKing_controlledSquares()
+    {
+        PieceHelper blackKing = e8.getPieceHelper();
+
+        assertEquals( 5, blackKing.getControlledSquares().size() );
+
+        assertTrue( blackKing.controls( d8 ) );
+        assertTrue( blackKing.controls( d7 ) );
+        assertTrue( blackKing.controls( e7 ) );
+        assertTrue( blackKing.controls( f8 ) );
+        assertTrue( blackKing.controls( f7 ) );
+    }
+
+    // ============================================================================================
+    // Helper Classes
+    // ============================================================================================
+
+    private class SquareHelper
+    {
+        private final char file;
+        private final char rank;
+
+        private SquareHelper( char file, char rank )
+        {
+            this.file = file;
+            this.rank = rank;
+        }
+
+        private Square getSquare()
+        {
+            return game.getActiveBoard().getSquare( file, rank );
+        }
+
+        private Piece getPiece()
+        {
+            return getSquare().getPiece();
+        }
+
+        private PieceHelper getPieceHelper()
+        {
+            return new PieceHelper( getPiece() );
+        }
+    }
+
+    private class PieceHelper
+    {
+        private final Piece piece;
+
+        private PieceHelper( Piece piece )
+        {
+            this.piece = piece;
+        }
+
+        private List<Square> getControlledSquares()
+        {
+            return piece.getControlledSquares( game.getActiveBoard() );
+        }
+
+        private boolean controls( SquareHelper squareHelper )
+        {
+            return piece.controls( squareHelper.getSquare(), game.getActiveBoard() );
+        }
     }
 }


### PR DESCRIPTION
Ensure pawns control their diagonal squares independently of whether a capture can currently be made there, so castling is disallowed when an opposing pawn controls the king's transit square.

Before and after:

<img width=49% alt="Castling allowed" src="https://github.com/user-attachments/assets/de59d3f9-ba57-4d0d-b6ca-e68b17b4a595" />

<img width=49% alt="Castling not allowed" src="https://github.com/user-attachments/assets/10dc1b35-129a-440f-883b-cf7e39978f54" />

Refactor piece movement logic to distinguish candidate squares, pseudo-legal destination squares and legal destination squares.